### PR TITLE
GitHub ActionsのSecretをSHARED_ACCOUNT_IDに変更

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::${{ secrets.SHARED_ACCOUNT_ID }}:role/zuntalk-shared-github-actions
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
## 概要
GitHub ActionsのSecretsをシンプルにしました。

## 変更内容
- `AWS_ROLE_ARN`から`SHARED_ACCOUNT_ID`に変更
- Role名はハードコードして管理を簡素化
- AWSアカウントIDのみSecretsで管理

## 必要な設定
GitHubリポジトリのSecretsに`SHARED_ACCOUNT_ID`を設定してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)