### PR TITLE
強制アップデート・メンテナンスチェック機能を追加

### DIFF
--- a/ios/ZunTalk/App/ZunTalkApp.swift
+++ b/ios/ZunTalk/App/ZunTalkApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct ZunTalkApp: App {
     var body: some Scene {
         WindowGroup {
-            ContactView()
+            LaunchView()
                 .preferredColorScheme(.light)
         }
     }

--- a/ios/ZunTalk/Models/AppStatus.swift
+++ b/ios/ZunTalk/Models/AppStatus.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// アプリの起動時ステータス
+enum AppStatus {
+    case loading
+    case ready
+    case maintenance
+    case updateRequired(currentVersion: String, minimumVersion: String)
+    case error(String)
+}

--- a/ios/ZunTalk/Repository/AppInfo/AppInfoRepository.swift
+++ b/ios/ZunTalk/Repository/AppInfo/AppInfoRepository.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+enum AppInfoError: Error {
+    case networkError(Error)
+    case decodingError
+    case invalidResponse
+}
+
+protocol AppInfoRepositoryProtocol {
+    func fetchAppInfo() async throws -> AppInfoResponse
+}
+
+class AppInfoRepository: AppInfoRepositoryProtocol {
+
+    func fetchAppInfo() async throws -> AppInfoResponse {
+        let url = URL(string: APIConfig.infoEndpoint)!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let httpResponse = response as? HTTPURLResponse {
+                guard httpResponse.statusCode == 200 else {
+                    print("AppInfo API Error: \(httpResponse.statusCode)")
+                    if let errorString = String(data: data, encoding: .utf8) {
+                        print("Error Response: \(errorString)")
+                    }
+                    throw AppInfoError.invalidResponse
+                }
+            }
+
+            let appInfo = try JSONDecoder().decode(AppInfoResponse.self, from: data)
+            return appInfo
+        } catch let error as AppInfoError {
+            throw error
+        } catch is DecodingError {
+            throw AppInfoError.decodingError
+        } catch {
+            throw AppInfoError.networkError(error)
+        }
+    }
+}

--- a/ios/ZunTalk/Repository/AppInfo/Entity/AppInfoResponse.swift
+++ b/ios/ZunTalk/Repository/AppInfo/Entity/AppInfoResponse.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Lambda API /api/info のレスポンス
+struct AppInfoResponse: Codable {
+    let maintenance: Bool
+    let minimumVersion: String
+}

--- a/ios/ZunTalk/Screens/Launch/LaunchView.swift
+++ b/ios/ZunTalk/Screens/Launch/LaunchView.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+struct LaunchView: View {
+    @StateObject private var viewModel = LaunchViewModel()
+
+    var body: some View {
+        Group {
+            switch viewModel.appStatus {
+            case .loading:
+                LoadingView()
+            case .ready:
+                ContactView()
+            case .maintenance:
+                MaintenanceView()
+            case .updateRequired(let currentVersion, let minimumVersion):
+                UpdateRequiredView(
+                    currentVersion: currentVersion,
+                    minimumVersion: minimumVersion,
+                    onUpdateTapped: {
+                        viewModel.openAppStore()
+                    }
+                )
+            case .error(let message):
+                ErrorView(message: message) {
+                    Task {
+                        await viewModel.checkAppStatus()
+                    }
+                }
+            }
+        }
+        .task {
+            await viewModel.checkAppStatus()
+        }
+    }
+}
+
+// MARK: - Loading View
+
+struct LoadingView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            ProgressView()
+                .scaleEffect(1.5)
+            Text("Loading...")
+                .font(.headline)
+                .foregroundColor(.gray)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
+    }
+}
+
+// MARK: - Maintenance View
+
+struct MaintenanceView: View {
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "wrench.and.screwdriver")
+                .font(.system(size: 60))
+                .foregroundColor(.orange)
+
+            Text("メンテナンス中")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text("現在メンテナンスを行っています。\nしばらくお待ちください。")
+                .font(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
+    }
+}
+
+// MARK: - Update Required View
+
+struct UpdateRequiredView: View {
+    let currentVersion: String
+    let minimumVersion: String
+    let onUpdateTapped: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "arrow.down.app")
+                .font(.system(size: 60))
+                .foregroundColor(.blue)
+
+            Text("アップデートが必要です")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text("新しいバージョンがリリースされています。\nApp Storeからアップデートしてください。")
+                .font(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            VStack(spacing: 4) {
+                Text("現在のバージョン: \(currentVersion)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Text("必要なバージョン: \(minimumVersion)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Button(action: onUpdateTapped) {
+                Text("App Storeを開く")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .cornerRadius(12)
+            }
+            .padding(.horizontal, 40)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
+    }
+}
+
+// MARK: - Error View
+
+struct ErrorView: View {
+    let message: String
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 60))
+                .foregroundColor(.red)
+
+            Text("エラーが発生しました")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text(message)
+                .font(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            Button(action: onRetry) {
+                Text("再試行")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .cornerRadius(12)
+            }
+            .padding(.horizontal, 40)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
+    }
+}
+
+#Preview {
+    LaunchView()
+}

--- a/ios/ZunTalk/Screens/Launch/LaunchViewModel.swift
+++ b/ios/ZunTalk/Screens/Launch/LaunchViewModel.swift
@@ -1,0 +1,83 @@
+import Foundation
+import UIKit
+
+@MainActor
+class LaunchViewModel: ObservableObject {
+    @Published var appStatus: AppStatus = .loading
+
+    private let appInfoRepository: AppInfoRepositoryProtocol
+
+    init(appInfoRepository: AppInfoRepositoryProtocol = AppInfoRepository()) {
+        self.appInfoRepository = appInfoRepository
+    }
+
+    func checkAppStatus() async {
+        appStatus = .loading
+
+        do {
+            let appInfo = try await appInfoRepository.fetchAppInfo()
+
+            // メンテナンス中チェック
+            if appInfo.maintenance {
+                appStatus = .maintenance
+                return
+            }
+
+            // バージョンチェック
+            let currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
+
+            if isUpdateRequired(currentVersion: currentVersion, minimumVersion: appInfo.minimumVersion) {
+                appStatus = .updateRequired(currentVersion: currentVersion, minimumVersion: appInfo.minimumVersion)
+                return
+            }
+
+            // 正常
+            appStatus = .ready
+        } catch {
+            print("AppInfo fetch error: \(error)")
+            // エラー時は一旦アプリを使用可能にする（オフライン対応）
+            appStatus = .ready
+        }
+    }
+
+    /// バージョン比較（セマンティックバージョニング）
+    private func isUpdateRequired(currentVersion: String, minimumVersion: String) -> Bool {
+        let current = parseVersion(currentVersion)
+        let minimum = parseVersion(minimumVersion)
+
+        // メジャーバージョン比較
+        if current.major < minimum.major {
+            return true
+        } else if current.major > minimum.major {
+            return false
+        }
+
+        // マイナーバージョン比較
+        if current.minor < minimum.minor {
+            return true
+        } else if current.minor > minimum.minor {
+            return false
+        }
+
+        // パッチバージョン比較
+        return current.patch < minimum.patch
+    }
+
+    private func parseVersion(_ version: String) -> (major: Int, minor: Int, patch: Int) {
+        let components = version.split(separator: ".").compactMap { Int($0) }
+        return (
+            major: components.count > 0 ? components[0] : 0,
+            minor: components.count > 1 ? components[1] : 0,
+            patch: components.count > 2 ? components[2] : 0
+        )
+    }
+
+    /// App Storeを開く
+    func openAppStore() {
+        // TODO: リリース後にApp Store IDを設定して有効化する
+        // let appStoreURL = "https://apps.apple.com/app/idXXXXXXXXXX"
+        // if let url = URL(string: appStoreURL) {
+        //     UIApplication.shared.open(url)
+        // }
+    }
+}


### PR DESCRIPTION
## Summary
- 起動時にAPI(/api/info)を呼び出し、メンテナンス状態と最低バージョンをチェック
- LaunchView/LaunchViewModelを追加し、アプリ状態に応じた画面を表示
- セマンティックバージョニングによるバージョン比較を実装
- エラー時はオフライン対応としてアプリを使用可能にする

## 追加ファイル
- `AppStatus.swift` - アプリ状態のenum
- `AppInfoRepository.swift` - API呼び出し
- `AppInfoResponse.swift` - APIレスポンスモデル
- `LaunchView.swift` - 起動画面（Loading/Maintenance/UpdateRequired/Error）
- `LaunchViewModel.swift` - 起動時チェックロジック

## Test plan
- [x] アプリ起動時にLoading画面が表示されることを確認
- [ ] API正常時にContactViewに遷移することを確認
- [ ] maintenance=trueの場合にメンテナンス画面が表示されることを確認
- [ ] minimumVersionが現在より高い場合にアップデート必要画面が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)