### PR TITLE
fix: GitHub Pagesデプロイ方法を修正

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,11 +11,17 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Deploy MkDocs to GitHub Pages
+  build:
+    name: Build Documentation
     runs-on: ubuntu-latest
 
     steps:
@@ -36,5 +42,20 @@ jobs:
       - name: Build documentation
         run: mkdocs build
 
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 問題
gh-pagesブランチを使った旧式のデプロイ方法を使用していたため、GitHub Pagesが正しく設定されず、アクセスできない状態でした。

## 解決策
`actions/deploy-pages@v4` を使用した公式の推奨デプロイ方法に変更しました。

## 変更内容
- ✅ `actions/deploy-pages@v4` を使用
- ✅ `actions/upload-pages-artifact@v3` でビルド成果物をアップロード
- ✅ build/deployジョブを分離
- ✅ permissions更新（pages: write, id-token: write）
- ✅ gh-pagesブランチ不要

## メリット
- GitHub Pagesの公式推奨方法
- より安全（OIDC認証）
- gh-pagesブランチの管理不要
- デプロイ履歴がActions上で確認可能

## 参考
https://github.com/takoikatakotako/rikako

## 確認事項
マージ後、GitHub リポジトリの **Settings > Pages** で：
- Source: `GitHub Actions` が自動選択されます
- デプロイ完了後、 https://takoikatakotako.github.io/ZunTalk/ でアクセス可能になります