### PR TITLE
chore: 古いVOICEVOXリソースを削除するマイグレーション処理を追加

### DIFF
--- a/ios/ZunTalk/Repository/TextToSpeech/VoicevoxRepository.swift
+++ b/ios/ZunTalk/Repository/TextToSpeech/VoicevoxRepository.swift
@@ -12,13 +12,13 @@ class VoicevoxRepository: TextToSpeechRepository {
         // コピー不要。setupSynthesizer()で直接バンドルから読み込む。
         print("✅ VOICEVOX resources are ready in bundle (no copy needed)")
 
-        // MIGRATION: v1.5.0 - 古いDocumentsディレクトリのリソースを削除
-        // v1.6.0以降で削除予定
+        // MIGRATION: v1.2.0 - 古いDocumentsディレクトリのリソースを削除
+        // v1.3.0以降で削除予定
         try? await cleanupLegacyResources()
     }
 
     /// 古いバージョンでDocumentsにコピーしていたVOICEVOXリソースを削除
-    /// - Note: v1.5.0で追加、v1.6.0以降で削除予定
+    /// - Note: v1.2.0で追加、v1.3.0以降で削除予定
     private func cleanupLegacyResources() async throws {
         let fileManager = FileManager.default
         guard let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {


### PR DESCRIPTION
## 概要
v1.2.0以前のバージョンでDocumentsディレクトリにコピーされていたVOICEVOXリソース（約300MB）を自動削除するマイグレーション処理を追加。

## 背景
PR #35でVOICEVOXリソースをバンドルから直接読み込むように変更したため、Documentsディレクトリへのコピーが不要になりました。しかし、既存ユーザーのデバイスには古いリソースが残ったままになっており、約300MBのディスク容量を無駄に消費しています。

## 変更内容
- ✅ `installVoicevox()`にマイグレーション処理を追加
- ✅ Documentsディレクトリから以下を削除:
  - `open_jtalk_dic_utf_8-1.11` (辞書データ)
  - `vvms` (音声モデル)
- ✅ UserDefaults管理不要（シンプルに存在すれば削除）

## メリット
- 💾 既存ユーザーのディスク容量を約300MB解放
- 🧹 不要なリソースのクリーンアップ

## 今後の対応
- v1.2.0でリリース
- v1.3.0以降でこのマイグレーション処理自体も削除予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)