### PR TITLE
Firebase Analytics + Crashlytics導入

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -70,6 +70,10 @@ jobs:
           mkdir -p ios/ZunTalk/vvms
           cp libs/voicevox_core/voicevox_core-0.16.3/models/vvms/*.vvm ios/ZunTalk/vvms/
 
+          # Firebase設定ファイルを配置
+          echo "Copying GoogleService-Info.plist..."
+          cp libs/firebase/GoogleService-Info.plist ios/ZunTalk/
+
           # 配置結果を確認
           echo "Frameworks in ios/Voicevox:"
           ls -la ios/Voicevox/

--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ libs/
 TempKey
 TempKey.*
 
+# Firebase
+**/GoogleService-Info.plist
+
 # Go
 backend/tmp/
 backend/*.exe

--- a/ios/ZunTalk.xcodeproj/project.pbxproj
+++ b/ios/ZunTalk.xcodeproj/project.pbxproj
@@ -345,7 +345,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" -gsp \"${PROJECT_DIR}/ZunTalk/GoogleService-Info.plist\"\n";
+			shellScript = "if [ -f \"${PROJECT_DIR}/ZunTalk/GoogleService-Info.plist\" ]; then\n  \"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" -gsp \"${PROJECT_DIR}/ZunTalk/GoogleService-Info.plist\"\nelse\n  echo \"warning: GoogleService-Info.plist not found, skipping dSYM upload\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios/ZunTalk.xcodeproj/project.pbxproj
+++ b/ios/ZunTalk.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		176AC9AD2E48FB1C00A4F009 /* voicevox_core.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 176AC9AB2E48FB1C00A4F009 /* voicevox_core.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		176AC9B02E48FB4100A4F009 /* voicevox_onnxruntime.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176AC9AF2E48FB4100A4F009 /* voicevox_onnxruntime.xcframework */; };
 		176AC9B12E48FB4100A4F009 /* voicevox_onnxruntime.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 176AC9AF2E48FB4100A4F009 /* voicevox_onnxruntime.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		179559922F66D6E60071E7FB /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 179559912F66D6E60071E7FB /* FirebaseAnalytics */; };
+		179559942F66D6E60071E7FB /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = 179559932F66D6E60071E7FB /* FirebaseAnalyticsCore */; };
+		179559962F66D6E60071E7FB /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 179559952F66D6E60071E7FB /* FirebaseCore */; };
+		179559982F66D6E60071E7FB /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 179559972F66D6E60071E7FB /* FirebaseCrashlytics */; };
 		17AE5B662F378E6700BAC024 /* open_jtalk_dic_utf_8-1.11 in Resources */ = {isa = PBXBuildFile; fileRef = 17AE5B652F378E6600BAC024 /* open_jtalk_dic_utf_8-1.11 */; };
 		17AE5B682F378E7600BAC024 /* vvms in Resources */ = {isa = PBXBuildFile; fileRef = 17AE5B672F378E7600BAC024 /* vvms */; };
 		17DD5D532EEB21EB00DA8574 /* Development.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 17DD5D522EEB21EB00DA8574 /* Development.xcconfig */; };
@@ -108,7 +112,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				176AC9B02E48FB4100A4F009 /* voicevox_onnxruntime.xcframework in Frameworks */,
+				179559962F66D6E60071E7FB /* FirebaseCore in Frameworks */,
 				176AC9AC2E48FB1C00A4F009 /* voicevox_core.xcframework in Frameworks */,
+				179559982F66D6E60071E7FB /* FirebaseCrashlytics in Frameworks */,
+				179559922F66D6E60071E7FB /* FirebaseAnalytics in Frameworks */,
+				179559942F66D6E60071E7FB /* FirebaseAnalyticsCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -174,6 +182,7 @@
 				1780EE5D2E313B1A00CF634A /* Frameworks */,
 				1780EE5E2E313B1A00CF634A /* Resources */,
 				176AC9AE2E48FB1C00A4F009 /* Embed Frameworks */,
+				179559992F66D7820071E7FB /* Upload dSYMs to Crashlytics */,
 			);
 			buildRules = (
 			);
@@ -184,6 +193,10 @@
 			);
 			name = ZunTalk;
 			packageProductDependencies = (
+				179559912F66D6E60071E7FB /* FirebaseAnalytics */,
+				179559932F66D6E60071E7FB /* FirebaseAnalyticsCore */,
+				179559952F66D6E60071E7FB /* FirebaseCore */,
+				179559972F66D6E60071E7FB /* FirebaseCrashlytics */,
 			);
 			productName = ZunTalk;
 			productReference = 1780EE602E313B1A00CF634A /* ZunTalk.app */;
@@ -267,6 +280,9 @@
 			);
 			mainGroup = 1780EE572E313B1A00CF634A;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				179559902F66D6E60071E7FB /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 1780EE612E313B1A00CF634A /* Products */;
 			projectDirPath = "";
@@ -306,6 +322,32 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		179559992F66D7820071E7FB /* Upload dSYMs to Crashlytics */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+				"${PROJECT_DIR}/ZunTalk/GoogleService-Info.plist",
+			);
+			name = "Upload dSYMs to Crashlytics";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" -gsp \"${PROJECT_DIR}/ZunTalk/GoogleService-Info.plist\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		1780EE5C2E313B1A00CF634A /* Sources */ = {
@@ -524,6 +566,7 @@
 				DEVELOPMENT_TEAM = 5RH346BQ66;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -658,6 +701,40 @@
 			defaultConfigurationName = Development;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		179559902F66D6E60071E7FB /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.10.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		179559912F66D6E60071E7FB /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 179559902F66D6E60071E7FB /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		179559932F66D6E60071E7FB /* FirebaseAnalyticsCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 179559902F66D6E60071E7FB /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsCore;
+		};
+		179559952F66D6E60071E7FB /* FirebaseCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 179559902F66D6E60071E7FB /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCore;
+		};
+		179559972F66D6E60071E7FB /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 179559902F66D6E60071E7FB /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 1780EE582E313B1A00CF634A /* Project object */;
 }

--- a/ios/ZunTalk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/ZunTalk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,123 @@
+{
+  "originHash" : "c63c63846d9c539229e96de38d6af51417e28c0ee9a0bc48bd0f0f19d923c329",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "85560b48b0ff099ad83fe53d67df3c67fbc2b7a6",
+        "version" : "12.10.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "a5cd95c80e8efdd02155c6cea1cecf743bb683a5",
+        "version" : "3.3.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "68ba955e540dcff5e0805970ef4b1fd0150be100",
+        "version" : "12.10.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a883ddb9fd464216133a5ab441f1ae8995978573",
+        "version" : "5.1.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios/ZunTalk.xcodeproj/xcshareddata/xcschemes/ZunTalk-Production.xcscheme
+++ b/ios/ZunTalk.xcodeproj/xcshareddata/xcschemes/ZunTalk-Production.xcscheme
@@ -8,7 +8,7 @@
       buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForTesting = "YES"
+            buildForTesting = "NO"
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"

--- a/ios/ZunTalk/App/ZunTalkApp.swift
+++ b/ios/ZunTalk/App/ZunTalkApp.swift
@@ -1,7 +1,12 @@
 import SwiftUI
+import FirebaseCore
 
 @main
 struct ZunTalkApp: App {
+    init() {
+        FirebaseApp.configure()
+    }
+
     var body: some Scene {
         WindowGroup {
             LaunchView()


### PR DESCRIPTION
## Summary
- Firebase SDK (Analytics, Crashlytics, Core) をSPMで追加
- GoogleService-Info.plistを配置し、`FirebaseApp.configure()`で初期化
- Crashlytics dSYMアップロード用Run Script Phaseを追加
- ProductionビルドでもENABLE_TESTABILITYを有効化（ローカルビルド対応）

## Test plan
- [x] Development スキームでビルド・実行成功
- [x] Production スキームでビルド成功
- [ ] Firebase Console で Crashlytics にアプリが表示されること
- [ ] CI が通ること

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)