### PR TITLE
feat: Firebase Analytics イベント実装

### DIFF
--- a/ios/ZunTalk/Screens/Chat/ChatView.swift
+++ b/ios/ZunTalk/Screens/Chat/ChatView.swift
@@ -189,4 +189,3 @@ private struct TypingIndicatorView: View {
         ChatView()
     }
 }
-

--- a/ios/ZunTalk/Screens/Chat/ChatViewModel.swift
+++ b/ios/ZunTalk/Screens/Chat/ChatViewModel.swift
@@ -57,6 +57,7 @@ class ChatViewModel: NSObject, ObservableObject {
 
     func onAppear() {
         guard messages.isEmpty else { return }
+        AnalyticsManager.logChatStarted()
         generateInitialGreeting()
     }
 
@@ -68,12 +69,13 @@ class ChatViewModel: NSObject, ObservableObject {
         messages.append(DisplayMessage(role: .user, content: text))
         chatMessages.append(ChatMessage(role: .user, content: text))
 
+        let userMessageCount = messages.filter { $0.role == .user }.count
+        AnalyticsManager.logMessageSent(messageCount: userMessageCount)
+
         isLoading = true
 
         Task {
             do {
-                // 上限チェック（ユーザーメッセージ数で判定）
-                let userMessageCount = messages.filter { $0.role == .user }.count
                 if userMessageCount >= Constants.maxRoundTrips {
                     chatMessages.append(ChatMessage(role: .system, content: Constants.endConversationPrompt))
                 }

--- a/ios/ZunTalk/Screens/Onboarding/OnboardingView.swift
+++ b/ios/ZunTalk/Screens/Onboarding/OnboardingView.swift
@@ -52,6 +52,7 @@ struct OnboardingView: View {
 
                     // 始めるボタン
                     Button(action: {
+                        AnalyticsManager.logOnboardingCompleted()
                         onComplete()
                     }) {
                         Text("始める")

--- a/ios/ZunTalk/Utilities/AnalyticsManager.swift
+++ b/ios/ZunTalk/Utilities/AnalyticsManager.swift
@@ -1,0 +1,17 @@
+import FirebaseAnalytics
+
+enum AnalyticsManager {
+    static func logOnboardingCompleted() {
+        Analytics.logEvent("onboarding_completed", parameters: nil)
+    }
+
+    static func logChatStarted() {
+        Analytics.logEvent("chat_started", parameters: nil)
+    }
+
+    static func logMessageSent(messageCount: Int) {
+        Analytics.logEvent("message_sent", parameters: [
+            "message_count": messageCount
+        ])
+    }
+}

--- a/ios/ZunTalkUITests/ZunTalkUITests.swift
+++ b/ios/ZunTalkUITests/ZunTalkUITests.swift
@@ -36,8 +36,8 @@ final class ZunTalkUITests: XCTestCase {
         let app = createTestApp()
         app.launch()
 
-        // アプリが起動したことを確認（CI環境では60秒に延長）
-        let appRunning = app.wait(for: .runningForeground, timeout: 60)
+        // アプリが起動したことを確認（CI環境では90秒に延長）
+        let appRunning = app.wait(for: .runningForeground, timeout: 90)
         XCTAssertTrue(appRunning, "App should be running in foreground")
     }
 


### PR DESCRIPTION
## Summary

- `AnalyticsManager` を新規追加（`ios/ZunTalk/Utilities/AnalyticsManager.swift`）
- オンボーディング完了時（`onboarding_completed`）、チャット開始時（`chat_started`）、メッセージ送信時（`message_sent`）の3イベントを計測

## 変更内容

| イベント名 | タイミング | パラメータ |
|---|---|---|
| `onboarding_completed` | 利用規約に同意して「始める」ボタンタップ | なし |
| `chat_started` | チャット画面が初回表示 | なし |
| `message_sent` | メッセージ送信 | `message_count`（何回目のメッセージか） |

## 確認方法

- Xcode でシミュレータ起動時に `-FIRAnalyticsDebugEnabled` の起動引数を追加
- Firebase Console の DebugView でイベントが届いていることを確認

Closes #71