### PR TITLE
release: iOS v1.4.1

### DIFF
--- a/ios/ZunTalk.xcodeproj/project.pbxproj
+++ b/ios/ZunTalk.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiswiswift.zuntalk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -612,7 +612,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiswiswift.zuntalk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
## 概要

iOS v1.4.1 リリース

## 変更内容

- 着信音が取得できない場合でも通話を継続するよう修正（Crashlytics で検知は継続）
- エラー音声のアセット名を `voice/` namespace 付きに修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)