### PR TITLE
fix: Lambdaデプロイ時にupdate-function-codeの出力をログへ露出しないよう修正

### DIFF
--- a/.github/workflows/backend-deploy-dev.yml
+++ b/.github/workflows/backend-deploy-dev.yml
@@ -57,6 +57,10 @@ jobs:
 
       - name: Deploy to Lambda (Dev)
         run: |
-          aws lambda update-function-code \
+          # 出力に Environment.Variables（OPENAI_API_KEY 等）が含まれログに露出するため、Version のみ取得
+          VERSION=$(aws lambda update-function-code \
             --function-name ${{ env.LAMBDA_FUNCTION_NAME }} \
-            --image-uri ${{ steps.build-image.outputs.image_uri }}
+            --image-uri ${{ steps.build-image.outputs.image_uri }} \
+            --publish \
+            --output text --query 'Version')
+          echo "Published version: $VERSION"

--- a/.github/workflows/backend-deploy-prod.yml
+++ b/.github/workflows/backend-deploy-prod.yml
@@ -55,6 +55,10 @@ jobs:
           IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
           echo "Deploying $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG to $LAMBDA_FUNCTION_NAME"
-          aws lambda update-function-code \
+          # 出力に Environment.Variables（OPENAI_API_KEY 等）が含まれログに露出するため、Version のみ取得
+          VERSION=$(aws lambda update-function-code \
             --function-name ${{ env.LAMBDA_FUNCTION_NAME }} \
-            --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+            --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            --publish \
+            --output text --query 'Version')
+          echo "Published version: $VERSION"

--- a/.github/workflows/slack-notifier-deploy-dev.yml
+++ b/.github/workflows/slack-notifier-deploy-dev.yml
@@ -57,6 +57,10 @@ jobs:
 
       - name: Deploy to Lambda (Dev)
         run: |
-          aws lambda update-function-code \
+          # 出力に Environment.Variables が含まれログに露出するため、Version のみ取得
+          VERSION=$(aws lambda update-function-code \
             --function-name ${{ env.LAMBDA_FUNCTION_NAME }} \
-            --image-uri ${{ steps.build-image.outputs.image_uri }}
+            --image-uri ${{ steps.build-image.outputs.image_uri }} \
+            --publish \
+            --output text --query 'Version')
+          echo "Published version: $VERSION"

--- a/.github/workflows/slack-notifier-deploy-prod.yml
+++ b/.github/workflows/slack-notifier-deploy-prod.yml
@@ -55,6 +55,10 @@ jobs:
           IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
           echo "Deploying $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG to $LAMBDA_FUNCTION_NAME"
-          aws lambda update-function-code \
+          # 出力に Environment.Variables が含まれログに露出するため、Version のみ取得
+          VERSION=$(aws lambda update-function-code \
             --function-name ${{ env.LAMBDA_FUNCTION_NAME }} \
-            --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+            --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            --publish \
+            --output text --query 'Version')
+          echo "Published version: $VERSION"


### PR DESCRIPTION
## 背景

GitHub Actions の Lambda デプロイワークフローが `aws lambda update-function-code` のレスポンス JSON をそのまま Actions ログに出力していた。このレスポンスには Lambda の `Environment.Variables` が含まれるため、`OPENAI_API_KEY` が **Public リポジトリの Actions ログに平文で露出**していた。

姉妹リポジトリ `takoikatakotako/rikako` で同じ問題が発見・修正済み（[rikako#196](https://github.com/takoikatakotako/rikako/pull/196) / [issue#198](https://github.com/takoikatakotako/rikako/issues/198)）で、ZunTalk でも同パターンを確認したため対応する。

### 確認済みの漏洩
| Workflow | 漏洩 |
|----------|------|
| `backend-deploy-dev.yml` | あり（dev key） |
| `backend-deploy-prod.yml` | あり（prod key） |
| `slack-notifier-deploy-dev.yml` | 現状なし・構造的に脆弱（予防修正） |
| `slack-notifier-deploy-prod.yml` | 同上 |

## 変更内容

`aws lambda update-function-code` を `--publish --output text --query 'Version'` で `Version` のみ取得する形に変更し、レスポンス JSON のログ露出を防止。既存のデプロイ挙動は維持。

## 別途必要な対応（このPR外・人間対応）

- [ ] 漏洩した OpenAI API Key（dev/prod）の **revoke → 再発行 → Lambda 環境変数更新**（最優先）
- [ ] `OPENAI_API_KEY` を含む過去 Actions run ログの削除（最終防御）

🤖 Generated with [Claude Code](https://claude.com/claude-code)