### PR TITLE
共有 OIDC プロバイダを data 参照に変更 (dev/prod)

### DIFF
--- a/terraform/environments/dev/github_actions.tf
+++ b/terraform/environments/dev/github_actions.tf
@@ -1,15 +1,11 @@
 # =============================================================================
 # GitHub Actions OIDC Provider
 # =============================================================================
-
-resource "aws_iam_openid_connect_provider" "github_actions" {
-  url             = "https://token.actions.githubusercontent.com"
-  client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = [var.github_oidc_thumbprint]
-
-  tags = {
-    Name = "github-actions-oidc-provider"
-  }
+# OIDC プロバイダーは AWS アカウントに1つしか作れない共有リソース。
+# このアカウントでは charalarm 側が本体を管理しているため、ZunTalk は
+# data で参照するのみとし、tags/thumbprint には一切触れない。
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
 }
 
 # =============================================================================
@@ -22,7 +18,7 @@ data "aws_iam_policy_document" "github_actions_assume_role" {
 
     principals {
       type        = "Federated"
-      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+      identifiers = [data.aws_iam_openid_connect_provider.github_actions.arn]
     }
 
     actions = ["sts:AssumeRoleWithWebIdentity"]

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -3,7 +3,3 @@
 # =============================================================================
 
 slack_notifier_image_uri = "448049807848.dkr.ecr.ap-northeast-1.amazonaws.com/zuntalk-slack-notifier:latest"
-
-# GitHub Actions OIDC thumbprint
-# AWSは2023年7月以降検証しなくなったが、Terraformの必須パラメータのため設定
-github_oidc_thumbprint = "6938fd4d98bab03faadb97b34396831e3780aea1"

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -8,11 +8,3 @@ variable "slack_notifier_image_uri" {
   description = "ECR image URI for slack notifier Lambda"
   type        = string
 }
-
-# GitHub Actions OIDC thumbprint
-# AWSは2023年7月以降、GitHub ActionsのOIDCプロバイダーについてthumbprintを検証しなくなった
-# ただしTerraformのaws_iam_openid_connect_providerは必須パラメータのため設定が必要
-variable "github_oidc_thumbprint" {
-  description = "GitHub Actions OIDC provider thumbprint (not validated by AWS since July 2023)"
-  type        = string
-}

--- a/terraform/environments/prod/github_actions.tf
+++ b/terraform/environments/prod/github_actions.tf
@@ -1,15 +1,11 @@
 # =============================================================================
 # GitHub Actions OIDC Provider
 # =============================================================================
-
-resource "aws_iam_openid_connect_provider" "github_actions" {
-  url             = "https://token.actions.githubusercontent.com"
-  client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = [var.github_oidc_thumbprint]
-
-  tags = {
-    Name = "github-actions-oidc-provider"
-  }
+# OIDC プロバイダーは AWS アカウントに1つしか作れない共有リソース。
+# このアカウントでは charalarm 側が本体を管理しているため、ZunTalk は
+# data で参照するのみとし、tags/thumbprint には一切触れない。
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
 }
 
 # =============================================================================
@@ -22,7 +18,7 @@ data "aws_iam_policy_document" "github_actions_assume_role" {
 
     principals {
       type        = "Federated"
-      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+      identifiers = [data.aws_iam_openid_connect_provider.github_actions.arn]
     }
 
     actions = ["sts:AssumeRoleWithWebIdentity"]

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -3,7 +3,3 @@
 # =============================================================================
 
 slack_notifier_image_uri = "448049807848.dkr.ecr.ap-northeast-1.amazonaws.com/zuntalk-slack-notifier:latest"
-
-# GitHub Actions OIDC thumbprint
-# AWSは2023年7月以降検証しなくなったが、Terraformの必須パラメータのため設定
-github_oidc_thumbprint = "6938fd4d98bab03faadb97b34396831e3780aea1"

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -8,11 +8,3 @@ variable "slack_notifier_image_uri" {
   description = "ECR image URI for slack notifier Lambda"
   type        = string
 }
-
-# GitHub Actions OIDC thumbprint
-# AWSは2023年7月以降、GitHub ActionsのOIDCプロバイダーについてthumbprintを検証しなくなった
-# ただしTerraformのaws_iam_openid_connect_providerは必須パラメータのため設定が必要
-variable "github_oidc_thumbprint" {
-  description = "GitHub Actions OIDC provider thumbprint (not validated by AWS since July 2023)"
-  type        = string
-}


### PR DESCRIPTION
## 概要

GitHub OIDC プロバイダ (`token.actions.githubusercontent.com`) は AWS アカウントに1つしか存在しない共有リソースです。dev / prod のアカウントは **charalarm と共有**しており、プロバイダ本体は charalarm 側で管理されています。

ZunTalk も `resource` として管理していたため、双方の apply で `default_tags`（`Project` など）や `thumbprint_list` を奪い合うドリフトが発生していました。charalarm を正とし、ZunTalk 側は **`data` 参照のみ**に切り替えて本体に触れないようにします。

## 変更内容

- `aws_iam_openid_connect_provider.github_actions` を `resource` → `data` に変更（dev / prod）
- assume-role ポリシーの `identifiers` 参照を `data.` 側に修正
- 不要になった `github_oidc_thumbprint` 変数と `terraform.tfvars` の値を削除
- `shared` 環境は元々 `var.github_oidc_provider_arn` を参照するだけで本体を管理していないため変更なし

## 適用手順（マージ後）

本体を削除しないよう、apply 前に state から外します:

\`\`\`
terraform state rm aws_iam_openid_connect_provider.github_actions
terraform apply   # data 参照に切り替わり、ロールは同一 ARN のため実質無変更
\`\`\`

## 確認事項

- [x] `terraform fmt`
- [x] dev / prod で `terraform validate` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)