### PR TITLE
GitHub Actions を Node.js 24 対応版へ更新

### DIFF
--- a/.github/workflows/backend-deploy-dev.yml
+++ b/.github/workflows/backend-deploy-dev.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials (Shared - for ECR)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.SHARED_ACCOUNT_ID }}:role/zuntalk-shared-github-actions
           aws-region: ${{ env.AWS_REGION }}
@@ -50,7 +50,7 @@ jobs:
           echo "image_uri=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Configure AWS credentials (Dev - for Lambda)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.DEV_ACCOUNT_ID }}:role/zuntalk-dev-github-actions
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/backend-deploy-prod.yml
+++ b/.github/workflows/backend-deploy-prod.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials (Shared - for ECR)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.SHARED_ACCOUNT_ID }}:role/zuntalk-shared-github-actions
           aws-region: ${{ env.AWS_REGION }}
@@ -44,7 +44,7 @@ jobs:
             --image-ids imageTag=$IMAGE_TAG
 
       - name: Configure AWS credentials (Prod - for Lambda)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.PROD_ACCOUNT_ID }}:role/zuntalk-prod-github-actions
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/backend-status.yml
+++ b/.github/workflows/backend-status.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials (Dev)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.DEV_ACCOUNT_ID }}:role/zuntalk-dev-github-actions
           aws-region: ${{ env.AWS_REGION }}
@@ -72,7 +72,7 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Configure AWS credentials (Prod)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.PROD_ACCOUNT_ID }}:role/zuntalk-prod-github-actions
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -49,7 +49,7 @@ jobs:
           mkdocs build -d site/docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./site
 
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/ios-lint.yml
+++ b/.github/workflows/ios-lint.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install SwiftLint
         run: brew install swiftlint

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Show Xcode version
         run: xcodebuild -version
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::448049807848:role/zuntalk-shared-github-actions
           aws-region: ap-northeast-1
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: |

--- a/.github/workflows/slack-notifier-deploy-dev.yml
+++ b/.github/workflows/slack-notifier-deploy-dev.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials (Shared - for ECR)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.SHARED_ACCOUNT_ID }}:role/zuntalk-shared-github-actions
           aws-region: ${{ env.AWS_REGION }}
@@ -50,7 +50,7 @@ jobs:
           echo "image_uri=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Configure AWS credentials (Dev - for Lambda)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.DEV_ACCOUNT_ID }}:role/zuntalk-dev-github-actions
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/slack-notifier-deploy-prod.yml
+++ b/.github/workflows/slack-notifier-deploy-prod.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials (Shared - for ECR)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.SHARED_ACCOUNT_ID }}:role/zuntalk-shared-github-actions
           aws-region: ${{ env.AWS_REGION }}
@@ -44,7 +44,7 @@ jobs:
             --image-ids imageTag=$IMAGE_TAG
 
       - name: Configure AWS credentials (Prod - for Lambda)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.PROD_ACCOUNT_ID }}:role/zuntalk-prod-github-actions
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.9.0
 


### PR DESCRIPTION
## 概要
GitHub Actions の Node.js 20 ランタイムが 2026-06-16 に既定から外れ、デプロイ時に非推奨警告が出ていたため、各アクションを Node.js 24 対応の最新メジャーへ更新します。

## 変更内容
| アクション | 変更 | 対象ワークフロー |
|---|---|---|
| actions/checkout | v4 → v6 | 全般 |
| actions/setup-go | v5 → v6 | backend-test |
| actions/setup-python | v5 → v6 | docs |
| actions/upload-artifact | v4 → v7 | ios-test |
| actions/upload-pages-artifact | v3 → v5 | docs |
| actions/deploy-pages | v4 → v5 | docs |
| aws-actions/configure-aws-credentials | v4 → v6 | backend/slack/ios デプロイ系 |
| hashicorp/setup-terraform | v3 → v4 | terraform-ci |

## 据え置き
- `aws-actions/amazon-ecr-login@v2`: 最新 v2.x が既に Node.js 24 ランタイムのため変更不要

## 互換性の確認
- **configure-aws-credentials v5/v6**: v5 の破壊的変更は「無効な boolean 入力の扱い」のみ。本リポジトリでは `role-to-assume` / `aws-region` しか渡しておらず影響なし。v6 の追加要件（runner v2.327.1 以上）は GitHub ホストランナーで充足。
- **upload-artifact v7**: 追加された `archive` パラメータは任意のオプトインで、既存の `name` / `path` 利用のデフォルト挙動は不変。
- いずれも GitHub ホストランナー（ubuntu/macos-latest）で動作する最小ランナー要件を満たす。

## 関連
- LP デプロイ時に出ていた `Node.js 20 actions are deprecated` 警告の解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)