### PR TITLE
iOS テスト結果バンドルの出力先を固定して artifact 警告を解消

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -85,6 +85,7 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
             -skip-testing:ZunTalkUITests \
             -enableCodeCoverage YES \
+            -resultBundlePath build/Logs/Test/ZunTalkTests.xcresult \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO
 
@@ -93,5 +94,4 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-results
-          path: |
-            ios/build/Logs/Test/*.xcresult
+          path: ios/build/Logs/Test/ZunTalkTests.xcresult


### PR DESCRIPTION
## 概要
iOS Tests ワークフローで、テスト結果アップロード時に出ていた以下の警告を解消します。

```
No files were found with the provided path: ios/build/Logs/Test/*.xcresult. No artifacts will be uploaded.
```

## 原因
`xcodebuild test` に `-resultBundlePath` を指定していなかったため、結果バンドルが一時ディレクトリ（`/var/folders/.../ResultBundle_*.xcresult`）に出力されていた。一方 `upload-artifact` は `ios/build/Logs/Test/*.xcresult` を探していたため経路がズレ、毎回「ファイルが見つからない」警告になっていた。

## 変更内容
- `xcodebuild test` に `-resultBundlePath build/Logs/Test/ZunTalkTests.xcresult` を追加（`working-directory: ios` のため実体は `ios/build/Logs/Test/ZunTalkTests.xcresult`）
- `upload-artifact` の `path` を同一ファイルに明示

## 補足
- 機能・テスト内容への影響はなし（出力先の固定のみ）
- これにより、テスト失敗時にも xcresult が artifact として確実にアップロードされ、調査しやすくなる

🤖 Generated with [Claude Code](https://claude.com/claude-code)