### PR TITLE
本番 AdMob ID を設定

### DIFF
--- a/ios/Production.xcconfig
+++ b/ios/Production.xcconfig
@@ -6,6 +6,6 @@ API_BASE_URL = https:/$()/lywvkbddncitxwu436n6ypykd40hfytm.lambda-url.ap-northea
 // App Icon
 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon-Production
 
-// TODO: Replace with production AdMob IDs before App Store submission.
-ADMOB_APP_ID = ca-app-pub-3940256099942544~1458002511
-ADMOB_BANNER_AD_UNIT_ID = ca-app-pub-3940256099942544/2435281174
+// AdMob production IDs
+ADMOB_APP_ID = ca-app-pub-5587141252700968~1253632259
+ADMOB_BANNER_AD_UNIT_ID = ca-app-pub-5587141252700968/1201661366


### PR DESCRIPTION
## 概要
App Store 提出前に、`ios/Production.xcconfig` の AdMob ID を Google のテスト用から**本番値**へ差し替えます。

## 変更内容
| 設定 | Before（テスト用） | After（本番） |
|---|---|---|
| `ADMOB_APP_ID` | `ca-app-pub-3940256099942544~1458002511` | `ca-app-pub-5587141252700968~1253632259` |
| `ADMOB_BANNER_AD_UNIT_ID` | `ca-app-pub-3940256099942544/2435281174` | `ca-app-pub-5587141252700968/1201661366` |

- `Development.xcconfig` はテスト ID のまま据え置き（開発用として正しい挙動）

## 補足
- コード上、TestFlight 配信時は `sandboxReceipt` 判定で自動的にテスト広告が表示され、実広告が出るのは App Store 公開ビルドのみ。
- 本 PR をマージ後、リリースブランチ `release/ios/1.5.0`（PR #84）にも取り込んでから Archive すること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)