### PR TITLE
AdMob 関連のビルド警告を解消

### DIFF
--- a/ios/ZunTalk/Components/AdBannerView.swift
+++ b/ios/ZunTalk/Components/AdBannerView.swift
@@ -54,7 +54,7 @@ private struct BannerViewContainer: UIViewRepresentable {
     }
 
     private func adSize(for width: CGFloat) -> AdSize {
-        currentOrientationAnchoredAdaptiveBanner(width: max(width, 320))
+        largeAnchoredAdaptiveBanner(width: max(width, 320))
     }
 
     private static var rootViewController: UIViewController? {

--- a/ios/ZunTalk/Utilities/AdManager.swift
+++ b/ios/ZunTalk/Utilities/AdManager.swift
@@ -6,7 +6,7 @@ final class AdManager {
     static let shared = AdManager()
 
     /// Google 公式のテスト用バナー広告ユニットID
-    private static let testBannerAdUnitID = "ca-app-pub-3940256099942544/2435281174"
+    nonisolated private static let testBannerAdUnitID = "ca-app-pub-3940256099942544/2435281174"
 
     /// 表示するバナー広告ユニットID。
     /// Debug / TestFlight ではテスト広告、App Store 本番では Info.plist の値を使う。


### PR DESCRIPTION
## 概要
Archive 時に出ていた AdMob 関連のビルド警告を解消します。

## 対応した警告
1. **(3件) `main actor-isolated static property 'testBannerAdUnitID' can not be referenced from a nonisolated context`** — Swift 6 言語モードではエラー化
   - `AdManager` は `@MainActor` のため `testBannerAdUnitID` も MainActor 分離されていたが、`nonisolated` な `bannerAdUnitID` / フォールバックから参照していた
   - 定数（Sendable な String リテラル）なので **`nonisolated private static let`** に変更して解消
2. **(1件) `'currentOrientationAnchoredAdaptiveBanner(width:)' is deprecated`**
   - GoogleMobileAds 13.4.0 で非推奨。推奨の **`largeAnchoredAdaptiveBanner(width:)`**（`GADLargeAnchoredAdaptiveBannerAdSizeWithWidth`、向きを自動判定）へ置き換え

## 確認
- `xcodebuild build`（ZunTalk-Development）で上記4件の警告が消えることを確認済み
- 残る警告は `AppIntents.framework` 関連2件のみ（自コード外・無害）

## 補足（挙動の変化）
- `largeAnchoredAdaptiveBanner` は従来のアンカー型アダプティブより**バナーの最大高さが大きめ**になります（Google の現行推奨サイズ）。`AdBannerView` は `bannerViewDidReceiveAd` で実サイズの高さを動的に反映する作りのため、レイアウトは自動追従します。表示後にバナーがやや高くなる可能性がある点だけ留意してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)