### PR TITLE
Release 1.5.1: 輸出コンプラ申告 + xcconfig 同梱解消

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-06-11
+
+### Changed
+- 輸出コンプライアンスの自己申告キー（`ITSAppUsesNonExemptEncryption`）を追加し、アップロード時の暗号化に関する質問をスキップ（#88）
+
+### Fixed
+- ビルド設定ファイル（`Development.xcconfig` / `Production.xcconfig`）がアプリバンドルに同梱されていた問題を修正（Copy Bundle Resources から除外）（#89）
+
 ## [1.5.0] - 2026-06-06
 
 ### Added

--- a/ios/ZunTalk.xcodeproj/project.pbxproj
+++ b/ios/ZunTalk.xcodeproj/project.pbxproj
@@ -18,8 +18,6 @@
 		17F2A0022FCE390000000001 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 17F2A0012FCE390000000001 /* GoogleMobileAds */; };
 		17AE5B662F378E6700BAC024 /* open_jtalk_dic_utf_8-1.11 in Resources */ = {isa = PBXBuildFile; fileRef = 17AE5B652F378E6600BAC024 /* open_jtalk_dic_utf_8-1.11 */; };
 		17AE5B682F378E7600BAC024 /* vvms in Resources */ = {isa = PBXBuildFile; fileRef = 17AE5B672F378E7600BAC024 /* vvms */; };
-		17DD5D532EEB21EB00DA8574 /* Development.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 17DD5D522EEB21EB00DA8574 /* Development.xcconfig */; };
-		17DD5D552EEB21F800DA8574 /* Production.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 17DD5D542EEB21F800DA8574 /* Production.xcconfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -304,9 +302,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				17DD5D552EEB21F800DA8574 /* Production.xcconfig in Resources */,
 				17AE5B662F378E6700BAC024 /* open_jtalk_dic_utf_8-1.11 in Resources */,
-				17DD5D532EEB21EB00DA8574 /* Development.xcconfig in Resources */,
 				17AE5B682F378E7600BAC024 /* vvms in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -482,7 +478,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiswiswift.zuntalk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -616,7 +612,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiswiswift.zuntalk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/ios/ZunTalk/Info.plist
+++ b/ios/ZunTalk/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>API_BASE_URL</key>
 	<string>$(API_BASE_URL)</string>
 	<key>CFBundleIconName</key>


### PR DESCRIPTION
## 概要
1.5.1 のリリース。軽微な整備2件＋バージョン bump。

Closes #88
Closes #89

## 変更内容
### #88 輸出コンプライアンスの自己申告
- `ios/ZunTalk/Info.plist` に `ITSAppUsesNonExemptEncryption=false` を追加。
- これにより、TestFlight / App Store の各アップロードで輸出コンプライアンス（暗号化）の質問が表示されなくなる。
- 本アプリの暗号化は標準 HTTPS 等の免除対象のみ（独自暗号なし）。

### #89 xcconfig のバンドル同梱解消
- `Development.xcconfig` / `Production.xcconfig` を **Copy Bundle Resources から除外**（`.app`/`.ipa` への同梱を解消）。
- `baseConfigurationReference`（Development/Production 構成への割当）は**維持**。設定の適用方法は変わらない。

### バージョン
- `MARKETING_VERSION`: 1.5.0 → **1.5.1**（ビルド番号は据え置き）
- CHANGELOG に 1.5.1 を追記

## 検証（Production ビルド実機相当）
`xcodebuild build -scheme ZunTalk-Production`（成功）で、生成された `.app` を確認：
- ✅ バンドル内 `*.xcconfig`: **0個**（同梱解消）
- ✅ `ITSAppUsesNonExemptEncryption = false`
- ✅ `GADApplicationIdentifier = ca-app-pub-5587141252700968~1253632259`（xcconfig 由来の値が正しく解決＝設定は壊れていない）
- ✅ `CFBundleShortVersionString = 1.5.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)