### PR TITLE
Fix appStoreReceiptURL deprecation in AdManager

### DIFF
--- a/ios/ZunTalk/Utilities/AdManager.swift
+++ b/ios/ZunTalk/Utilities/AdManager.swift
@@ -28,7 +28,9 @@ final class AdManager {
         #if DEBUG
         return true
         #else
-        return Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+        // App Store 配信ビルドには embedded.mobileprovision が含まれない。
+        // TestFlight / 開発ビルドには含まれるため、その場合はテスト広告を使う。
+        return Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision") != nil
         #endif
     }
 


### PR DESCRIPTION
## 概要
iOS 18 で deprecated になった `Bundle.main.appStoreReceiptURL` を使った TestFlight 判定（`sandboxReceipt`）を解消する。

## 変更内容
`AdManager.shouldUseTestAds` の判定を、`embedded.mobileprovision` の有無による判定に置き換え。

- App Store 配信ビルド → プロファイル無し → **本番広告**
- TestFlight / 開発ビルド → プロファイル有り → **テスト広告**
- `#if DEBUG` → 従来どおりテスト広告

挙動は元のロジックと等価。`AdManager.bannerAdUnitID` は `AdBannerView.init` のデフォルト引数で同期的に使われるため、async な StoreKit2 `AppTransaction` ではなく同期APIで実装。

## 確認
- `xcodebuild` で `** BUILD SUCCEEDED **`、deprecation 警告が消えたことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)