### PR TITLE
Add embed mode to privacy/terms pages for in-app display

### DIFF
--- a/ios/ZunTalk/Screens/Config/ConfigView.swift
+++ b/ios/ZunTalk/Screens/Config/ConfigView.swift
@@ -49,7 +49,7 @@ struct ConfigView: View {
             }
 
             Section("法的情報") {
-                Link(destination: URL(string: "https://takoikatakotako.github.io/ZunTalk/terms.html")!) {
+                Link(destination: URL(string: "https://takoikatakotako.github.io/ZunTalk/terms.html?embed=1")!) {
                     HStack {
                         Label("利用規約", systemImage: "doc.text")
                         Spacer()
@@ -58,7 +58,7 @@ struct ConfigView: View {
                     }
                 }
 
-                Link(destination: URL(string: "https://takoikatakotako.github.io/ZunTalk/privacy.html")!) {
+                Link(destination: URL(string: "https://takoikatakotako.github.io/ZunTalk/privacy.html?embed=1")!) {
                     HStack {
                         Label("プライバシーポリシー", systemImage: "hand.raised")
                         Spacer()

--- a/ios/ZunTalk/Screens/Onboarding/OnboardingView.swift
+++ b/ios/ZunTalk/Screens/Onboarding/OnboardingView.swift
@@ -167,13 +167,13 @@ struct TermsAgreementText: View {
     }
 
     private func openTermsURL() {
-        if let url = URL(string: "https://takoikatakotako.github.io/ZunTalk/terms.html") {
+        if let url = URL(string: "https://takoikatakotako.github.io/ZunTalk/terms.html?embed=1") {
             UIApplication.shared.open(url)
         }
     }
 
     private func openPrivacyURL() {
-        if let url = URL(string: "https://takoikatakotako.github.io/ZunTalk/privacy.html") {
+        if let url = URL(string: "https://takoikatakotako.github.io/ZunTalk/privacy.html?embed=1") {
             UIApplication.shared.open(url)
         }
     }

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -7,6 +7,12 @@
   <meta name="description" content="ZunTalk のプライバシーポリシーです。" />
   <link rel="icon" href="assets/icon.png" />
   <link rel="stylesheet" href="styles.css" />
+  <script>
+    // アプリ内表示（?embed=1）ではサイトのヘッダー/フッターを隠す
+    if (new URLSearchParams(location.search).get('embed') === '1') {
+      document.documentElement.classList.add('embed');
+    }
+  </script>
 </head>
 <body>
   <!-- Header -->

--- a/landing/styles.css
+++ b/landing/styles.css
@@ -335,3 +335,10 @@ a { color: inherit; text-decoration: none; }
   border-top: 1px solid rgba(46, 125, 62, 0.15);
   margin: 40px 0;
 }
+
+/* ---------- Embed mode (アプリ内表示: ?embed=1) ---------- */
+/* アプリから ?embed=1 で開いたときはサイトのヘッダー/フッターを隠す */
+.embed .site-header,
+.embed .site-footer {
+  display: none;
+}

--- a/landing/terms.html
+++ b/landing/terms.html
@@ -7,6 +7,12 @@
   <meta name="description" content="ZunTalk の利用規約です。" />
   <link rel="icon" href="assets/icon.png" />
   <link rel="stylesheet" href="styles.css" />
+  <script>
+    // アプリ内表示（?embed=1）ではサイトのヘッダー/フッターを隠す
+    if (new URLSearchParams(location.search).get('embed') === '1') {
+      document.documentElement.classList.add('embed');
+    }
+  </script>
 </head>
 <body>
   <!-- Header -->


### PR DESCRIPTION
## 概要
アプリ内からプライバシーポリシー/利用規約を開いたとき、ランディングサイト用のヘッダー（特徴/利用規約/ダウンロード）とフッター（トップ/GitHub等）が一緒に表示され、アプリ文脈では不自然だった。`?embed=1` で開いたときだけそれらを隠す「埋め込みモード」を追加する。

法的文面は1ファイルのまま（二重管理なし）。

## 変更内容
### Web (`landing/`)
- `privacy.html` / `terms.html` の `<head>` に、`?embed=1` のとき `<html>` に `embed` クラスを付与する小さなスクリプトを追加（FOUC回避のため `documentElement` に付与）
- `styles.css` に `.embed .site-header, .embed .site-footer { display: none; }` を追加

### iOS
- `ConfigView` / `OnboardingView` のプラポリ・規約リンクURL（計4箇所）に `?embed=1` を付与
- 表示方法（外部Safari起動）は変更なし

## 確認
- ローカルで `privacy.html` と `privacy.html?embed=1` を開き、後者でヘッダー/フッターが消えることを確認
- `xcodebuild build -scheme ZunTalk-Development` で `** BUILD SUCCEEDED **`

## 注意
- `?embed=1` が効くのは main マージ後の GitHub Pages 再ビルド反映後（数分ラグ）
- 日付スナップショット（`privacy-2026-06-06.html` / `terms-2025-12-25.html`）は対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)