### PR TITLE
プラポリ/規約の embed モードを撤去

### DIFF
--- a/ios/ZunTalk/Screens/Config/ConfigView.swift
+++ b/ios/ZunTalk/Screens/Config/ConfigView.swift
@@ -49,7 +49,7 @@ struct ConfigView: View {
             }
 
             Section("法的情報") {
-                Link(destination: URL(string: "https://takoikatakotako.github.io/ZunTalk/terms.html?embed=1")!) {
+                Link(destination: URL(string: "https://takoikatakotako.github.io/ZunTalk/terms.html")!) {
                     HStack {
                         Label("利用規約", systemImage: "doc.text")
                         Spacer()
@@ -58,7 +58,7 @@ struct ConfigView: View {
                     }
                 }
 
-                Link(destination: URL(string: "https://takoikatakotako.github.io/ZunTalk/privacy.html?embed=1")!) {
+                Link(destination: URL(string: "https://takoikatakotako.github.io/ZunTalk/privacy.html")!) {
                     HStack {
                         Label("プライバシーポリシー", systemImage: "hand.raised")
                         Spacer()

--- a/ios/ZunTalk/Screens/Onboarding/OnboardingView.swift
+++ b/ios/ZunTalk/Screens/Onboarding/OnboardingView.swift
@@ -167,13 +167,13 @@ struct TermsAgreementText: View {
     }
 
     private func openTermsURL() {
-        if let url = URL(string: "https://takoikatakotako.github.io/ZunTalk/terms.html?embed=1") {
+        if let url = URL(string: "https://takoikatakotako.github.io/ZunTalk/terms.html") {
             UIApplication.shared.open(url)
         }
     }
 
     private func openPrivacyURL() {
-        if let url = URL(string: "https://takoikatakotako.github.io/ZunTalk/privacy.html?embed=1") {
+        if let url = URL(string: "https://takoikatakotako.github.io/ZunTalk/privacy.html") {
             UIApplication.shared.open(url)
         }
     }

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -7,12 +7,6 @@
   <meta name="description" content="ZunTalk のプライバシーポリシーです。" />
   <link rel="icon" href="assets/icon.png" />
   <link rel="stylesheet" href="styles.css" />
-  <script>
-    // アプリ内表示（?embed=1）ではサイトのヘッダー/フッターを隠す
-    if (new URLSearchParams(location.search).get('embed') === '1') {
-      document.documentElement.classList.add('embed');
-    }
-  </script>
 </head>
 <body>
   <!-- Header -->

--- a/landing/styles.css
+++ b/landing/styles.css
@@ -335,10 +335,3 @@ a { color: inherit; text-decoration: none; }
   border-top: 1px solid rgba(46, 125, 62, 0.15);
   margin: 40px 0;
 }
-
-/* ---------- Embed mode (アプリ内表示: ?embed=1) ---------- */
-/* アプリから ?embed=1 で開いたときはサイトのヘッダー/フッターを隠す */
-.embed .site-header,
-.embed .site-footer {
-  display: none;
-}

--- a/landing/terms.html
+++ b/landing/terms.html
@@ -7,12 +7,6 @@
   <meta name="description" content="ZunTalk の利用規約です。" />
   <link rel="icon" href="assets/icon.png" />
   <link rel="stylesheet" href="styles.css" />
-  <script>
-    // アプリ内表示（?embed=1）ではサイトのヘッダー/フッターを隠す
-    if (new URLSearchParams(location.search).get('embed') === '1') {
-      document.documentElement.classList.add('embed');
-    }
-  </script>
 </head>
 <body>
   <!-- Header -->


### PR DESCRIPTION
## 概要

プライバシーポリシー/利用規約ページの **embed モード（`?embed=1`）** を撤去します。

## 背景

直近の #94 で「アプリ内表示時にサイトのヘッダー/フッターを隠す」目的で embed モードを追加しました。
しかし調査の結果、その前提が成立していないことが判明しました:

- iOSコードベース全体に `WKWebView` / `SFSafariViewController` 等の **アプリ内ブラウザは存在しない**
- プラポリ/規約のリンクは2箇所とも **外部ブラウザ（Safari）** で開く実装
  - `ConfigView` … SwiftUI `Link(destination:)`
  - `OnboardingView` … `UIApplication.shared.open(url)`
- 外部Safariで開く以上、ヘッダー/フッターの表示はむしろ自然で隠す必要がない

→ embed モードは意図した効果を発揮しておらず、実質デッドコードのため撤去します。

## 変更内容

- `ConfigView.swift` / `OnboardingView.swift`: リンクURLから `?embed=1` を除去（各2箇所）
- `privacy.html` / `terms.html`: embed 判定スクリプトを削除
- `styles.css`: `.embed` 非表示ルールを削除

法的文面（本文）には一切手を入れていません。

## 検証

- [x] `grep embed` で embed 関連コードが残っていないことを確認
- [ ] iOSビルドが通り、設定/オンボーディング画面のリンクが `?embed=1` なしで外部Safariを開く
- [ ] `privacy.html` / `terms.html` をブラウザで開きヘッダー/フッターが通常表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)