### PR TITLE
通話の音声認識エラー耐性 + 電話発火の秒精度化

### DIFF
--- a/agent/handler/dispatch.go
+++ b/agent/handler/dispatch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -12,6 +13,10 @@ import (
 	"github.com/takoikatakotako/ZunTalk/agent/model"
 	"github.com/takoikatakotako/ZunTalk/agent/store"
 )
+
+// dispatchHorizon は1回の dispatch が先読みする時間幅。
+// Scheduler は毎分起動なので、次の起動までに期限が来る分をこの実行が受け持つ。
+const dispatchHorizon = 60 * time.Second
 
 // DispatchHandler は Cloud Scheduler から毎分呼ばれ、
 // 期限が到来した予約に VoIP push を送る。
@@ -47,27 +52,60 @@ func (h *DispatchHandler) HandleDispatch(c echo.Context) error {
 	}
 	res.Missed = missed
 
-	// 期限到来分を claim（多重実行しても claim できた実行だけが送る）
-	calls, err := h.store.ClaimDueCalls(ctx, now)
+	// 次の実行までに期限が来る予約を先読みし、発火時刻ちょうどに送る
+	//（毎分ポーリングのままで秒精度を出す。Scheduler の attempt_deadline は 90s）。
+	calls, err := h.store.ListUpcomingCalls(ctx, now, dispatchHorizon)
 	if err != nil {
-		slog.Error("Failed to claim due calls", "error", err)
+		slog.Error("Failed to list upcoming calls", "error", err)
 		return c.JSON(http.StatusInternalServerError, model.ErrorResponse{
 			Code:    "INTERNAL_ERROR",
 			Message: "予約の取得に失敗しました",
 		})
 	}
 
+	var (
+		wg sync.WaitGroup
+		mu sync.Mutex
+	)
 	for _, call := range calls {
-		if err := h.sendCall(c, call); err != nil {
-			slog.Error("Failed to send call push", "callId", call.ID, "deviceId", call.DeviceID, "error", err)
-			_ = h.store.MarkCallResult(ctx, call.ID, model.CallStatusFailed, err.Error())
-			res.Failed++
-			continue
-		}
-		slog.Info("Call push sent", "callId", call.ID, "deviceId", call.DeviceID)
-		_ = h.store.MarkCallResult(ctx, call.ID, model.CallStatusSent, "")
-		res.Dispatched++
+		wg.Add(1)
+		go func(call store.ScheduledCall) {
+			defer wg.Done()
+
+			// 発火時刻まで待つ
+			if wait := time.Until(call.ScheduledAt); wait > 0 {
+				select {
+				case <-time.After(wait):
+				case <-ctx.Done():
+					return // claim 前なので次の実行がそのまま処理できる
+				}
+			}
+
+			// 送信直前に claim（発火待ちの間にキャンセルされた場合はここで弾かれる）
+			claimed, err := h.store.ClaimCall(ctx, call.ID)
+			if err != nil {
+				if !errors.Is(err, store.ErrConflict) {
+					slog.Error("Failed to claim call", "callId", call.ID, "error", err)
+				}
+				return
+			}
+
+			if err := h.sendCall(c, *claimed); err != nil {
+				slog.Error("Failed to send call push", "callId", call.ID, "deviceId", call.DeviceID, "error", err)
+				_ = h.store.MarkCallResult(ctx, call.ID, model.CallStatusFailed, err.Error())
+				mu.Lock()
+				res.Failed++
+				mu.Unlock()
+				return
+			}
+			slog.Info("Call push sent", "callId", call.ID, "deviceId", call.DeviceID)
+			_ = h.store.MarkCallResult(ctx, call.ID, model.CallStatusSent, "")
+			mu.Lock()
+			res.Dispatched++
+			mu.Unlock()
+		}(call)
 	}
+	wg.Wait()
 
 	return c.JSON(http.StatusOK, res)
 }

--- a/agent/store/store.go
+++ b/agent/store/store.go
@@ -221,48 +221,60 @@ func (s *Store) CancelCall(ctx context.Context, callID, deviceID string) error {
 	})
 }
 
-// ClaimDueCalls は期限が到来した予約をトランザクションで sending に遷移させて返す。
-// 多重実行と重なっても、claim に成功した実行だけが push を送る。
-func (s *Store) ClaimDueCalls(ctx context.Context, now time.Time) ([]ScheduledCall, error) {
+// ListUpcomingCalls は「期限が到来済み〜horizon 以内に到来する」予約を返す（claim はしない）。
+// 毎分ポーリングでも秒精度で発火させるため、dispatcher は先読みして発火時刻まで待つ。
+func (s *Store) ListUpcomingCalls(ctx context.Context, now time.Time, horizon time.Duration) ([]ScheduledCall, error) {
 	now = now.UTC()
 	snaps, err := s.client.Collection(callsCollection).
 		Where("status", "==", model.CallStatusScheduled).
 		Where("scheduledAt", ">", now.Add(-dueGraceWindow)).
-		Where("scheduledAt", "<=", now).
+		Where("scheduledAt", "<=", now.Add(horizon)).
 		Limit(50).
 		Documents(ctx).GetAll()
 	if err != nil {
 		return nil, err
 	}
 
-	var claimed []ScheduledCall
+	calls := make([]ScheduledCall, 0, len(snaps))
 	for _, snap := range snaps {
-		ref := snap.Ref
 		var call ScheduledCall
-		err := s.client.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
-			fresh, err := tx.Get(ref)
-			if err != nil {
-				return err
-			}
-			if err := fresh.DataTo(&call); err != nil {
-				return err
-			}
-			if call.Status != model.CallStatusScheduled {
-				return ErrConflict // 別の実行が先に claim した
-			}
-			return tx.Update(ref, []firestore.Update{
-				{Path: "status", Value: model.CallStatusSending},
-				{Path: "updatedAt", Value: time.Now().UTC()},
-			})
-		})
-		if err != nil {
+		if err := snap.DataTo(&call); err != nil {
 			continue
 		}
-		call.ID = ref.ID
-		call.Status = model.CallStatusSending
-		claimed = append(claimed, call)
+		call.ID = snap.Ref.ID
+		calls = append(calls, call)
 	}
-	return claimed, nil
+	return calls, nil
+}
+
+// ClaimCall は予約をトランザクションで scheduled → sending に遷移させる。
+// 既に状態が変わっていた場合（キャンセル済み・別実行が claim 済み）は ErrConflict。
+// 送信の直前に claim することで、発火待ちの間のキャンセルも反映される。
+func (s *Store) ClaimCall(ctx context.Context, callID string) (*ScheduledCall, error) {
+	ref := s.client.Collection(callsCollection).Doc(callID)
+	var call ScheduledCall
+	err := s.client.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		fresh, err := tx.Get(ref)
+		if err != nil {
+			return err
+		}
+		if err := fresh.DataTo(&call); err != nil {
+			return err
+		}
+		if call.Status != model.CallStatusScheduled {
+			return ErrConflict
+		}
+		return tx.Update(ref, []firestore.Update{
+			{Path: "status", Value: model.CallStatusSending},
+			{Path: "updatedAt", Value: time.Now().UTC()},
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	call.ID = ref.ID
+	call.Status = model.CallStatusSending
+	return &call, nil
 }
 
 // MarkCallResult は送信結果を記録する。

--- a/ios/ZunTalk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/ZunTalk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c829433a5adb9148db4b60da14885faa6490490cab8a055c406d2cbcbfc8f3f3",
+  "originHash" : "1e1c7e60582e8f4992793669f6e300bfc8a82beeebe9fddab02512fe34f24bc8",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/ios/ZunTalk/Screens/Call/CallViewModel+SpeechRecognition.swift
+++ b/ios/ZunTalk/Screens/Call/CallViewModel+SpeechRecognition.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Speech
+import AVFoundation
+
+// MARK: - Speech Recognition
+
+/// 通話中の音声認識まわり。
+/// 認識エンジンの一時的な失敗（無音時の No speech detected 等）で
+/// 会話を終わらせないためのリトライを含む。
+extension CallViewModel {
+
+    /// 音声認識を最大3回試みる。無音や一時的な失敗では会話を終わらせず聞き直し、
+    /// 全滅した場合のみ nil を返す（呼び出し側は挨拶して通話を終える）。
+    func recognizeUserSpeechWithRetry() async -> String? {
+        for attempt in 1...3 {
+            guard !shouldDismiss else { return nil }
+            do {
+                let input = try await recognizeUserSpeech()
+                if !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    return input
+                }
+                print("音声認識が空でした（\(attempt)回目）")
+            } catch {
+                print("音声認識エラー（\(attempt)回目）: \(error)")
+                CrashlyticsManager.record(error)
+            }
+            resetRecognition()
+        }
+        return nil
+    }
+
+    /// 認識まわりの状態を破棄して、次の recognizeUserSpeech() をやり直せる状態に戻す。
+    private func resetRecognition() {
+        silenceTimer?.invalidate()
+        silenceTimer = nil
+        task?.cancel()
+        task = nil
+        request = nil
+        recognitionContinuation = nil
+        if engine.isRunning {
+            engine.stop()
+            engine.inputNode.removeTap(onBus: 0)
+        }
+    }
+
+    func requestSpeechRecognitionPermission() async -> Bool {
+        status = .requestingPermission
+
+        let authStatus = SFSpeechRecognizer.authorizationStatus()
+
+        switch authStatus {
+        case .authorized:
+            return true
+        case .denied, .restricted:
+            return false
+        case .notDetermined:
+            return await withCheckedContinuation { continuation in
+                SFSpeechRecognizer.requestAuthorization { status in
+                    continuation.resume(returning: status == .authorized)
+                }
+            }
+        @unknown default:
+            return false
+        }
+    }
+
+    private func recognizeUserSpeech() async throws -> String {
+        status = .recognizingSpeech
+        text = ""
+
+        // CallKit 通話中はカテゴリ固定・アクティブ化は CallKit 任せのため触らない
+        if mode == .simulated {
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setCategory(.playAndRecord, mode: .voiceChat, options: [.defaultToSpeaker, .mixWithOthers])
+            try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        }
+
+        request = SFSpeechAudioBufferRecognitionRequest()
+        request?.shouldReportPartialResults = true
+
+        let input = engine.inputNode
+        let format = input.outputFormat(forBus: 0)
+
+        input.removeTap(onBus: 0)
+        input.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            self?.request?.append(buffer)
+        }
+
+        task = recognizer?.recognitionTask(with: request!) { [weak self] result, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                print("音声認識エラー: \(error.localizedDescription)")
+                Task { @MainActor in
+                    self.recognitionContinuation?.resume(throwing: CallError.speechRecognitionFailed(error))
+                    self.recognitionContinuation = nil
+                }
+                return
+            }
+
+            guard let result = result, !result.isFinal else { return }
+
+            let recognizedText = result.bestTranscription.formattedString
+
+            DispatchQueue.main.async {
+                self.text = recognizedText
+            }
+
+            self.silenceTimer?.invalidate()
+            self.silenceTimer = Timer.scheduledTimer(
+                withTimeInterval: Constants.silenceDetectionTime,
+                repeats: false
+            ) { _ in
+                Task { @MainActor in
+                    self.stopRecognition()
+                }
+            }
+        }
+
+        try engine.start()
+
+        return try await withCheckedThrowingContinuation { continuation in
+            recognitionContinuation = continuation
+        }
+    }
+
+    private func stopRecognition() {
+        engine.stop()
+        engine.inputNode.removeTap(onBus: 0)
+        request?.endAudio()
+        task?.finish()
+
+        recognitionContinuation?.resume(returning: text)
+        recognitionContinuation = nil
+    }
+}

--- a/ios/ZunTalk/Screens/Call/CallViewModel.swift
+++ b/ios/ZunTalk/Screens/Call/CallViewModel.swift
@@ -15,9 +15,8 @@ class CallViewModel: NSObject, ObservableObject {
 
     // MARK: - Constants
 
-    private enum Constants {
-        // 短いほど会話のテンポが上がるが、話の途中で区切られやすくなる
-        static let silenceDetectionTime: TimeInterval = 1.2
+    enum Constants {
+        static let silenceDetectionTime: TimeInterval = 2.0
         static let maxConversationDuration: TimeInterval = 120.0
         static let conversationTimerInterval: TimeInterval = 1.0
         static let locale = Locale(identifier: "ja-JP")
@@ -30,7 +29,6 @@ class CallViewModel: NSObject, ObservableObject {
             最初のセリフは必ず「電話を受けた感のある挨拶」にしてください。
             例: 「もしもし〜？ずんだもんなのだ！」、「は〜い、ずんだもんなのだ！」、「お電話ありがとうなのだ！」など。
             例を参考にしつつ、毎回少し違う言い回しにしてください。
-            電話での会話なので、返答は1〜3文程度で短く、テンポよく話してください。
             暴力的・攻撃的・不快な発言はしないでください。
             """
 
@@ -40,17 +38,17 @@ class CallViewModel: NSObject, ObservableObject {
 
     // MARK: - Private Properties - Repositories
 
-    private let mode: CallMode
+    let mode: CallMode
     private let voicevoxRepository: TextToSpeechRepository
     private let textGenerationRepository: TextGenerationRepository
 
     // MARK: - Private Properties - Speech Recognition
 
-    private let recognizer = SFSpeechRecognizer(locale: Constants.locale)
-    private let engine = AVAudioEngine()
-    private var request: SFSpeechAudioBufferRecognitionRequest?
-    private var task: SFSpeechRecognitionTask?
-    private var recognitionContinuation: CheckedContinuation<String, Error>?
+    let recognizer = SFSpeechRecognizer(locale: Constants.locale)
+    let engine = AVAudioEngine()
+    var request: SFSpeechAudioBufferRecognitionRequest?
+    var task: SFSpeechRecognitionTask?
+    var recognitionContinuation: CheckedContinuation<String, Error>?
 
     // MARK: - Private Properties - Audio Playback
 
@@ -59,7 +57,7 @@ class CallViewModel: NSObject, ObservableObject {
 
     // MARK: - Private Properties - Timers
 
-    private var silenceTimer: Timer?
+    var silenceTimer: Timer?
     private var conversationTimer: Timer?
     private var speechRecognitionStartTime: Date?
 
@@ -283,133 +281,6 @@ class CallViewModel: NSObject, ObservableObject {
         if let audioData = currentAudioData {
             try await playVoice(audioData)
         }
-    }
-
-    // MARK: - Private Methods - Speech Recognition
-
-    /// 音声認識を最大3回試みる。無音（No speech detected 等）や一時的な失敗では
-    /// 会話を終わらせず聞き直し、全滅した場合のみ nil を返す。
-    private func recognizeUserSpeechWithRetry() async -> String? {
-        for attempt in 1...3 {
-            guard !shouldDismiss else { return nil }
-            do {
-                let input = try await recognizeUserSpeech()
-                if !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    return input
-                }
-                print("音声認識が空でした（\(attempt)回目）")
-            } catch {
-                print("音声認識エラー（\(attempt)回目）: \(error)")
-                CrashlyticsManager.record(error)
-            }
-            resetRecognition()
-        }
-        return nil
-    }
-
-    /// 認識まわりの状態を破棄して、次の recognizeUserSpeech() をやり直せる状態に戻す。
-    private func resetRecognition() {
-        silenceTimer?.invalidate()
-        silenceTimer = nil
-        task?.cancel()
-        task = nil
-        request = nil
-        recognitionContinuation = nil
-        if engine.isRunning {
-            engine.stop()
-            engine.inputNode.removeTap(onBus: 0)
-        }
-    }
-
-    private func requestSpeechRecognitionPermission() async -> Bool {
-        status = .requestingPermission
-
-        let authStatus = SFSpeechRecognizer.authorizationStatus()
-
-        switch authStatus {
-        case .authorized:
-            return true
-        case .denied, .restricted:
-            return false
-        case .notDetermined:
-            return await withCheckedContinuation { continuation in
-                SFSpeechRecognizer.requestAuthorization { status in
-                    continuation.resume(returning: status == .authorized)
-                }
-            }
-        @unknown default:
-            return false
-        }
-    }
-
-    private func recognizeUserSpeech() async throws -> String {
-        status = .recognizingSpeech
-        text = ""
-
-        // CallKit 通話中はカテゴリ固定・アクティブ化は CallKit 任せのため触らない
-        if mode == .simulated {
-            let audioSession = AVAudioSession.sharedInstance()
-            try audioSession.setCategory(.playAndRecord, mode: .voiceChat, options: [.defaultToSpeaker, .mixWithOthers])
-            try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
-        }
-
-        request = SFSpeechAudioBufferRecognitionRequest()
-        request?.shouldReportPartialResults = true
-
-        let input = engine.inputNode
-        let format = input.outputFormat(forBus: 0)
-
-        input.removeTap(onBus: 0)
-        input.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
-            self?.request?.append(buffer)
-        }
-
-        task = recognizer?.recognitionTask(with: request!) { [weak self] result, error in
-            guard let self = self else { return }
-
-            if let error = error {
-                print("音声認識エラー: \(error.localizedDescription)")
-                Task { @MainActor in
-                    self.recognitionContinuation?.resume(throwing: CallError.speechRecognitionFailed(error))
-                    self.recognitionContinuation = nil
-                }
-                return
-            }
-
-            guard let result = result, !result.isFinal else { return }
-
-            let recognizedText = result.bestTranscription.formattedString
-
-            DispatchQueue.main.async {
-                self.text = recognizedText
-            }
-
-            self.silenceTimer?.invalidate()
-            self.silenceTimer = Timer.scheduledTimer(
-                withTimeInterval: Constants.silenceDetectionTime,
-                repeats: false
-            ) { _ in
-                Task { @MainActor in
-                    self.stopRecognition()
-                }
-            }
-        }
-
-        try engine.start()
-
-        return try await withCheckedThrowingContinuation { continuation in
-            recognitionContinuation = continuation
-        }
-    }
-
-    private func stopRecognition() {
-        engine.stop()
-        engine.inputNode.removeTap(onBus: 0)
-        request?.endAudio()
-        task?.finish()
-
-        recognitionContinuation?.resume(returning: text)
-        recognitionContinuation = nil
     }
 
     // MARK: - Private Methods - Text Generation

--- a/ios/ZunTalk/Screens/Call/CallViewModel.swift
+++ b/ios/ZunTalk/Screens/Call/CallViewModel.swift
@@ -16,7 +16,8 @@ class CallViewModel: NSObject, ObservableObject {
     // MARK: - Constants
 
     private enum Constants {
-        static let silenceDetectionTime: TimeInterval = 2.0
+        // 短いほど会話のテンポが上がるが、話の途中で区切られやすくなる
+        static let silenceDetectionTime: TimeInterval = 1.2
         static let maxConversationDuration: TimeInterval = 120.0
         static let conversationTimerInterval: TimeInterval = 1.0
         static let locale = Locale(identifier: "ja-JP")
@@ -29,10 +30,12 @@ class CallViewModel: NSObject, ObservableObject {
             最初のセリフは必ず「電話を受けた感のある挨拶」にしてください。
             例: 「もしもし〜？ずんだもんなのだ！」、「は〜い、ずんだもんなのだ！」、「お電話ありがとうなのだ！」など。
             例を参考にしつつ、毎回少し違う言い回しにしてください。
+            電話での会話なので、返答は1〜3文程度で短く、テンポよく話してください。
             暴力的・攻撃的・不快な発言はしないでください。
             """
 
         static let endConversationPrompt = "会話時間が2分を超えたので、ずんだもんらしく親しみやすい挨拶で会話を終了してください。"
+        static let noInputEndPrompt = "ユーザーの声が聞こえなくなったので、少し心配しつつ、ずんだもんらしい親しみやすい挨拶で会話を終了してください。"
     }
 
     // MARK: - Private Properties - Repositories
@@ -175,8 +178,14 @@ class CallViewModel: NSObject, ObservableObject {
     private func conversationLoop() async throws {
         guard !shouldDismiss else { return }
 
-        // ユーザーの音声を認識
-        let userInput = try await recognizeUserSpeech()
+        // ユーザーの音声を認識（無音や一時的な認識失敗は聞き直す）
+        guard let userInput = await recognizeUserSpeechWithRetry() else {
+            // 聞き取れないまま続いた場合は、エラーにせず挨拶して通話を終える
+            if !shouldDismiss {
+                try await endConversation(prompt: Constants.noInputEndPrompt)
+            }
+            return
+        }
         guard !shouldDismiss else { return }
 
         // 会話時間を確認
@@ -204,9 +213,9 @@ class CallViewModel: NSObject, ObservableObject {
         try await conversationLoop()
     }
 
-    private func endConversation() async throws {
+    private func endConversation(prompt: String = Constants.endConversationPrompt) async throws {
         // 終了メッセージを生成するためのプロンプトを追加
-        chatMessages.append(ChatMessage(role: .system, content: Constants.endConversationPrompt))
+        chatMessages.append(ChatMessage(role: .system, content: prompt))
 
         // 終了メッセージを生成
         status = .generatingScript
@@ -277,6 +286,40 @@ class CallViewModel: NSObject, ObservableObject {
     }
 
     // MARK: - Private Methods - Speech Recognition
+
+    /// 音声認識を最大3回試みる。無音（No speech detected 等）や一時的な失敗では
+    /// 会話を終わらせず聞き直し、全滅した場合のみ nil を返す。
+    private func recognizeUserSpeechWithRetry() async -> String? {
+        for attempt in 1...3 {
+            guard !shouldDismiss else { return nil }
+            do {
+                let input = try await recognizeUserSpeech()
+                if !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    return input
+                }
+                print("音声認識が空でした（\(attempt)回目）")
+            } catch {
+                print("音声認識エラー（\(attempt)回目）: \(error)")
+                CrashlyticsManager.record(error)
+            }
+            resetRecognition()
+        }
+        return nil
+    }
+
+    /// 認識まわりの状態を破棄して、次の recognizeUserSpeech() をやり直せる状態に戻す。
+    private func resetRecognition() {
+        silenceTimer?.invalidate()
+        silenceTimer = nil
+        task?.cancel()
+        task = nil
+        request = nil
+        recognitionContinuation = nil
+        if engine.isRunning {
+            engine.stop()
+            engine.inputNode.removeTap(onBus: 0)
+        }
+    }
 
     private func requestSpeechRecognitionPermission() async -> Bool {
         status = .requestingPermission

--- a/terraform/gcp/environments/dev/main.tf
+++ b/terraform/gcp/environments/dev/main.tf
@@ -209,8 +209,10 @@ module "call_dispatch_scheduler" {
   project_id  = var.project_id
   region      = var.region
   name        = "${local.agent_name}-call-dispatch"
-  description = "期限到来した電話予約の VoIP push 送信（毎分）"
+  description = "期限到来した電話予約の VoIP push 送信（毎分・60秒先読みで秒精度発火）"
   schedule    = "* * * * *"
+  # dispatch は次の60秒以内の予約を発火時刻まで待ってから送るため、1分より長めに取る
+  attempt_deadline = "90s"
 
   uri                   = "${module.agent_cloud_run.service_uri}/internal/dispatch"
   service_account_email = module.call_dispatcher_service_account.email


### PR DESCRIPTION
## 概要

### 1. 会話中エラーの修正（音声認識の耐性）
TestFlight 実機で「会話の途中でエラーなのだ」と通話が終了する事象が発生。調査の結果、サーバー側（Lambda /api/chat）は該当時間帯すべて 200 で、**クライアント側の SFSpeechRecognizer の一時的失敗（無音時の No speech detected 等）が1回で即 throw → エラー終了**する実装が原因と特定（Crashlytics の非致命エラーでも確認予定）。

- 音声認識の失敗・空認識は**最大3回聞き直す**
- それでも聞き取れない場合はエラーにせず、**ずんだもんが心配しつつ挨拶して通話を終える**（noInputEndPrompt）
- 認識まわりを `CallViewModel+SpeechRecognition.swift` に分離（file_length/type_body_length 対応）

### 2. 電話発火の秒精度化（#102）
毎分ポーリングのため最大59秒遅れていた。dispatch が**次の60秒以内の予約を先読み**し、発火時刻まで待ってから claim → APNs 送信する方式に変更。

- `store.ListUpcomingCalls`（claim なし先読み）+ `store.ClaimCall`（送信直前の単発 claim）
- 発火待ち中のキャンセルは claim 時に検出されるため、**予約直前キャンセルも正しく効く**ようになった（副次改善）
- Cloud Scheduler の `attempt_deadline` を 60s → 90s（要 terraform apply）

会話高速化（無音判定短縮・短文化・バージイン）は #103 として分離し、本PRには含めない。

## 検証
- [x] go build / vet / test
- [x] xcodebuild（Development）+ SwiftLint --strict
- [x] terraform validate
- [ ] マージ後: terraform apply（attempt_deadline）→ agent デプロイ（main への push で自動）→ 実機で予約→秒精度着信の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)