### PR TITLE
prod エージェント環境を完全化し、本番アプリを prod Cloud Run へ切り替え

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 端末が実行可能なツールを申告する capability ネゴシエーションを追加（現状は `calendar` のみ）
   - deviceId ごとの `/agent` 日次利用回数制限（`AGENT_DAILY_LIMIT`、デフォルト50）で Vertex AI のコスト保護。上限超過は 429 でずんだもん口調のメッセージを表示
 - プライバシーポリシーにカレンダーデータの扱いを追記
+- prod GCP 環境を完全化（電話予約インフラ一式）し、本番アプリを prod Cloud Run へ切り替え（#108）
 
 ### Changed
 - `FeatureFlags` を分割: `agentModeEnabled` を本番でも有効に、開発者向け UI（エージェントテスト・表情確認）は `debugToolsEnabled`（Debug 限定）に分離
+- Firestore を dev/prod で分離。接続先DBを `FIRESTORE_DATABASE` で切り替え（dev=`(default)` / prod=`zuntalk-prod`）。各環境が自分のDB・インデックス・TTL を所有し、prod のプロジェクト分割にコード変更なしで対応できる構成に（#108）
 
 ### Removed
 - Gmail 連携（Google Sign-In）を全面削除。設定画面の Google 連携 UI・`GoogleAuthManager`・`GmailTool`・`gmail` capability、GoogleSignIn SDK と OAuth 設定（client ID・URL スキーム）を撤去。カレンダーは EventKit のみで完結（Firebase / AdMob は影響なし）

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -1,6 +1,10 @@
 # Vertex AI を呼ぶ Google Cloud プロジェクトID（必須）
 GCP_PROJECT_ID=your-gcp-project-id
 
+# 接続する Firestore データベースID（dev/prod 分離用）。未設定なら (default)。
+# dev は (default)、prod は専用DB（例: zuntalk-prod）を指す。
+FIRESTORE_DATABASE=(default)
+
 # Vertex AI のリージョン（例: us-central1, asia-northeast1）
 VERTEX_LOCATION=us-central1
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -127,7 +127,10 @@ iOS の PushKit/CallKit で着信、という流れ。
 - `scheduledCalls/{id}`: deviceId / scheduledAt(UTC) / status（scheduled→sending→sent|failed、canceled/missed）
 - `agentUsage/{yyyy-mm-dd}_{deviceId}`: /agent の日次呼び出し回数（expireAt の TTL で7日後に自動削除）
 - 複合インデックス `(status ASC, scheduledAt ASC)` が必要（Terraform で定義済み）
-- **注意**: Firestore の `(default)` DB はプロジェクトに1つ。dev/prod は同じ DB・コレクションを共有する
+- **接続先データベースは `FIRESTORE_DATABASE` で切り替える**（未設定なら `(default)`）。
+  dev は `(default)`、prod は専用の名前付きDB `zuntalk-prod` を使い、**データを完全分離**する。
+  各環境が自分のDB・インデックス・TTL を Terraform で所有するため、将来 prod を
+  別プロジェクト・別アカウントへ移しても追従できる。
 
 ### 手動 push テスト（サーバー不要）
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -11,6 +11,9 @@ type Config struct {
 	Port string
 	// GCPProjectID は Vertex AI を呼ぶ Google Cloud プロジェクトID。
 	GCPProjectID string
+	// FirestoreDatabase は接続する Firestore データベースID。
+	// dev/prod で分離するために使う。空・未設定なら "(default)"。
+	FirestoreDatabase string
 	// VertexLocation は Vertex AI のリージョン（例: us-central1, asia-northeast1）。
 	VertexLocation string
 	// GeminiModel は使用する Gemini モデル名。
@@ -38,12 +41,13 @@ type Config struct {
 // Load は環境変数から設定を読み込む。
 func Load() *Config {
 	return &Config{
-		Port:            getEnv("PORT", "8080"),
-		GCPProjectID:    getEnv("GCP_PROJECT_ID", ""),
-		VertexLocation:  getEnv("VERTEX_LOCATION", "us-central1"),
-		GeminiModel:     getEnv("GEMINI_MODEL", "gemini-2.5-flash"),
-		APIKey:          getEnv("AGENT_API_KEY", ""),
-		AgentDailyLimit: getEnvInt("AGENT_DAILY_LIMIT", 50),
+		Port:              getEnv("PORT", "8080"),
+		GCPProjectID:      getEnv("GCP_PROJECT_ID", ""),
+		FirestoreDatabase: getEnv("FIRESTORE_DATABASE", "(default)"),
+		VertexLocation:    getEnv("VERTEX_LOCATION", "us-central1"),
+		GeminiModel:       getEnv("GEMINI_MODEL", "gemini-2.5-flash"),
+		APIKey:            getEnv("AGENT_API_KEY", ""),
+		AgentDailyLimit:   getEnvInt("AGENT_DAILY_LIMIT", 50),
 
 		APNSKeyID:               getEnv("APNS_KEY_ID", ""),
 		APNSTeamID:              getEnv("APNS_TEAM_ID", ""),

--- a/agent/main.go
+++ b/agent/main.go
@@ -40,7 +40,7 @@ func main() {
 	orch := orchestrator.New(gemini)
 
 	// Firestore（電話予約・端末トークンの保存先）を初期化（ADC でキーレス認証）。
-	st, err := store.New(ctx, cfg.GCPProjectID)
+	st, err := store.New(ctx, cfg.GCPProjectID, cfg.FirestoreDatabase)
 	if err != nil {
 		log.Fatalf("failed to init Firestore client: %v", err)
 	}

--- a/agent/store/store.go
+++ b/agent/store/store.go
@@ -78,8 +78,13 @@ type Store struct {
 }
 
 // New は Firestore クライアントを初期化する。
-func New(ctx context.Context, projectID string) (*Store, error) {
-	client, err := firestore.NewClient(ctx, projectID)
+// databaseID で接続先データベースを指定する（dev/prod 分離用）。
+// 空なら "(default)" を使う。
+func New(ctx context.Context, projectID, databaseID string) (*Store, error) {
+	if databaseID == "" {
+		databaseID = "(default)"
+	}
+	client, err := firestore.NewClientWithDatabase(ctx, projectID, databaseID)
 	if err != nil {
 		return nil, fmt.Errorf("store: failed to init firestore client: %w", err)
 	}

--- a/docs/architecture/system.md
+++ b/docs/architecture/system.md
@@ -89,9 +89,9 @@
 
 #### 技術スタック
 - **言語**: Go 1.24 + Echo v4
-- **実行環境**: Cloud Run（`zuntalk-agent-dev`）
+- **実行環境**: Cloud Run（`zuntalk-agent-dev` / `zuntalk-agent-prod`）
 - **AI**: Vertex AI（Gemini、ADC キーレス認証）
-- **データストア**: Firestore（devices / scheduledCalls / agentUsage）
+- **データストア**: Firestore（devices / scheduledCalls / agentUsage）。接続先DBは `FIRESTORE_DATABASE` で切り替え、dev は `(default)`・prod は `zuntalk-prod` でデータ分離
 
 #### エンドポイント
 - `POST /agent`: エージェント往復（X-Api-Key）
@@ -121,13 +121,12 @@
 - **Dev** (039612872248): 開発環境Lambda
 - **Prod** (986921280333): 本番環境Lambda
 
-#### GCP構成（エージェント / 電話予約）
-- **Cloud Run**: エージェントサーバー実行環境
+- **Cloud Run**: エージェントサーバー実行環境（dev / prod の2サービス）
 - **Vertex AI**: Gemini 呼び出し
-- **Firestore**: 端末トークン・電話予約・利用回数カウンタ（TTL ポリシー含め Terraform 管理）
-- **Cloud Scheduler**: 毎分のディスパッチ（OIDC 認証）
+- **Firestore**: 端末トークン・電話予約・利用回数カウンタ（TTL ポリシー含め Terraform 管理）。dev は `(default)` DB、prod は名前付きDB `zuntalk-prod` で**完全分離**。各環境が自分のDB・インデックス・TTL を所有し、将来 prod を別プロジェクト・別アカウントへ移せる構成
+- **Cloud Scheduler**: 毎分のディスパッチ（OIDC 認証）。dev / prod それぞれが自分のDBの `scheduledCalls` を処理する
 - **Secret Manager**: API キー・APNs Auth Key (.p8)
-- **プロジェクト**: sandbox-492513（`terraform/gcp/environments/dev`。prod 環境は未構築で、本番アプリも当面 dev Cloud Run を参照）
+- **プロジェクト**: 現状は dev/prod とも sandbox-492513 内（`terraform/gcp/environments/{dev,prod}`）。Firestore はDBレベルで分離済みなので、prod のプロジェクト分割にコード変更なしで対応できる
 
 ## データフロー
 

--- a/ios/Production.xcconfig
+++ b/ios/Production.xcconfig
@@ -7,8 +7,7 @@
 API_BASE_URL = https:/$()/lywvkbddncitxwu436n6ypykd40hfytm.lambda-url.ap-northeast-1.on.aws
 
 // Agent (Cloud Run) Base URL
-// TODO: prod 環境（zuntalk-agent-prod）構築後に切り替える。それまでは dev を参照
-AGENT_BASE_URL = https:/$()/zuntalk-agent-dev-exxyf6d72a-an.a.run.app
+AGENT_BASE_URL = https:/$()/zuntalk-agent-prod-exxyf6d72a-an.a.run.app
 
 // Bundle ID
 APP_BUNDLE_IDENTIFIER = com.swiswiswift.zuntalk

--- a/terraform/gcp/environments/dev/main.tf
+++ b/terraform/gcp/environments/dev/main.tf
@@ -70,9 +70,9 @@ module "call_dispatcher_service_account" {
 # =============================================================================
 # Firestore
 # =============================================================================
-# 注意: Firestore の (default) データベースはプロジェクトに1つのみ。
-# dev/prod は同じ sandbox プロジェクトを使うため、DB とインデックスは
-# dev 側でのみ定義し、prod は同じ DB（コレクションも共有）を参照する。
+# dev は (default) データベースを使う。prod は prod 環境が専用の名前付きDB
+# （zuntalk-prod）を別途定義し、データを完全分離する。将来 prod を別プロジェクト・
+# 別アカウントに移しても、各環境が自分のDB・インデックスを所有しているので追従できる。
 
 resource "google_firestore_database" "default" {
   project     = var.project_id
@@ -179,11 +179,12 @@ module "agent_cloud_run" {
   image                 = var.image
 
   environment_variables = {
-    APP_ENV           = local.environment
-    GCP_PROJECT_ID    = var.project_id
-    VERTEX_LOCATION   = var.vertex_location
-    GEMINI_MODEL      = var.gemini_model
-    AGENT_DAILY_LIMIT = tostring(var.agent_daily_limit)
+    APP_ENV            = local.environment
+    GCP_PROJECT_ID     = var.project_id
+    FIRESTORE_DATABASE = google_firestore_database.default.name
+    VERTEX_LOCATION    = var.vertex_location
+    GEMINI_MODEL       = var.gemini_model
+    AGENT_DAILY_LIMIT  = tostring(var.agent_daily_limit)
 
     APNS_KEY_ID               = var.apns_key_id
     APNS_TEAM_ID              = var.apns_team_id

--- a/terraform/gcp/environments/prod/main.tf
+++ b/terraform/gcp/environments/prod/main.tf
@@ -70,6 +70,56 @@ module "call_dispatcher_service_account" {
 }
 
 # =============================================================================
+# Firestore
+# =============================================================================
+# prod 専用の名前付きデータベース。dev の (default) とデータを完全分離する。
+# 将来 prod を別プロジェクト・別アカウントへ移しても、この環境が自分のDB・
+# インデックス・TTL を所有しているので追従できる。
+
+resource "google_firestore_database" "prod" {
+  project     = var.project_id
+  name        = "zuntalk-prod"
+  location_id = var.region
+  type        = "FIRESTORE_NATIVE"
+
+  delete_protection_state = "DELETE_PROTECTION_ENABLED"
+  deletion_policy         = "ABANDON"
+
+  depends_on = [module.project_services]
+}
+
+# ディスパッチャの期限到来クエリ（status == && scheduledAt 範囲）用の複合インデックス
+resource "google_firestore_index" "scheduled_calls_status_scheduled_at" {
+  project    = var.project_id
+  database   = google_firestore_database.prod.name
+  collection = "scheduledCalls"
+
+  fields {
+    field_path = "status"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "scheduledAt"
+    order      = "ASCENDING"
+  }
+}
+
+# /agent の日次利用回数カウンタ（agentUsage/{yyyy-mm-dd}_{deviceId}）を
+# expireAt フィールド基準の TTL で自動削除する（保持期間はアプリ側で7日に設定）。
+resource "google_firestore_field" "agent_usage_ttl" {
+  project    = var.project_id
+  database   = google_firestore_database.prod.name
+  collection = "agentUsage"
+  field      = "expireAt"
+
+  ttl_config {}
+
+  # TTL 用フィールドにインデックスは不要
+  index_config {}
+}
+
+# =============================================================================
 # Artifact Registry
 # =============================================================================
 
@@ -131,11 +181,12 @@ module "agent_cloud_run" {
   image                 = var.image
 
   environment_variables = {
-    APP_ENV           = local.environment
-    GCP_PROJECT_ID    = var.project_id
-    VERTEX_LOCATION   = var.vertex_location
-    GEMINI_MODEL      = var.gemini_model
-    AGENT_DAILY_LIMIT = tostring(var.agent_daily_limit)
+    APP_ENV            = local.environment
+    GCP_PROJECT_ID     = var.project_id
+    FIRESTORE_DATABASE = google_firestore_database.prod.name
+    VERTEX_LOCATION    = var.vertex_location
+    GEMINI_MODEL       = var.gemini_model
+    AGENT_DAILY_LIMIT  = tostring(var.agent_daily_limit)
 
     APNS_KEY_ID               = var.apns_key_id
     APNS_TEAM_ID              = var.apns_team_id
@@ -160,6 +211,7 @@ module "agent_cloud_run" {
     module.project_services,
     module.agent_api_key,
     module.agent_apns_key,
+    google_firestore_database.prod,
     google_project_iam_member.agent_runtime_vertex,
     google_project_iam_member.agent_runtime_datastore,
   ]

--- a/terraform/gcp/environments/prod/main.tf
+++ b/terraform/gcp/environments/prod/main.tf
@@ -1,13 +1,19 @@
 locals {
-  environment       = "prod"
-  agent_name        = "zuntalk-agent-${local.environment}"
-  api_key_secret_id = "${local.agent_name}-api-key"
+  environment        = "prod"
+  agent_name         = "zuntalk-agent-${local.environment}"
+  api_key_secret_id  = "${local.agent_name}-api-key"
+  apns_key_secret_id = "${local.agent_name}-apns-key"
+  # Scheduler の OIDC トークンと dispatch エンドポイントの照合に使う audience。
+  # Cloud Run の URL に依存させると自己参照になるため固定文字列にする。
+  dispatch_audience = "${local.agent_name}-dispatch"
   required_services = [
     "run.googleapis.com",
     "aiplatform.googleapis.com",
     "artifactregistry.googleapis.com",
     "secretmanager.googleapis.com",
     "iamcredentials.googleapis.com",
+    "firestore.googleapis.com",
+    "cloudscheduler.googleapis.com",
   ]
 }
 
@@ -43,6 +49,26 @@ resource "google_project_iam_member" "agent_runtime_vertex" {
   member  = "serviceAccount:${module.agent_runtime_service_account.email}"
 }
 
+# /agent の日次利用回数カウンタ（agentUsage）・電話予約（devices/scheduledCalls）を
+# Firestore に読み書きするため。DB 自体は dev 側が同一プロジェクトで共有管理している
+# （(default) は1プロジェクト1つ。dev/prod は同じ DB・コレクションを共有）。
+resource "google_project_iam_member" "agent_runtime_datastore" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${module.agent_runtime_service_account.email}"
+}
+
+# /internal/dispatch を毎分叩く Cloud Scheduler ジョブ用 SA
+module "call_dispatcher_service_account" {
+  source = "../../modules/service-account"
+
+  project_id   = var.project_id
+  account_id   = "call-dispatcher-${local.environment}"
+  display_name = "ZunTalk ${local.environment} 電話予約ディスパッチャ (Cloud Scheduler)"
+
+  depends_on = [module.project_services]
+}
+
 # =============================================================================
 # Artifact Registry
 # =============================================================================
@@ -75,6 +101,22 @@ module "agent_api_key" {
   depends_on = [module.project_services]
 }
 
+# APNs Auth Key (.p8) の中身。値は手動で投入する（TF には書かない）:
+#   gcloud secrets versions add zuntalk-agent-prod-apns-key --data-file=AuthKey_XXXX.p8 --project sandbox-492513
+# バージョン未投入のまま Cloud Run をデプロイすると起動に失敗するので注意。
+module "agent_apns_key" {
+  source = "../../modules/secret-manager-secret"
+
+  project_id           = var.project_id
+  secret_id            = local.apns_key_secret_id
+  replication_location = var.region
+  accessor_members = [
+    "serviceAccount:${module.agent_runtime_service_account.email}",
+  ]
+
+  depends_on = [module.project_services]
+}
+
 # =============================================================================
 # Cloud Run
 # =============================================================================
@@ -89,15 +131,25 @@ module "agent_cloud_run" {
   image                 = var.image
 
   environment_variables = {
-    APP_ENV         = local.environment
-    GCP_PROJECT_ID  = var.project_id
-    VERTEX_LOCATION = var.vertex_location
-    GEMINI_MODEL    = var.gemini_model
+    APP_ENV           = local.environment
+    GCP_PROJECT_ID    = var.project_id
+    VERTEX_LOCATION   = var.vertex_location
+    GEMINI_MODEL      = var.gemini_model
+    AGENT_DAILY_LIMIT = tostring(var.agent_daily_limit)
+
+    APNS_KEY_ID               = var.apns_key_id
+    APNS_TEAM_ID              = var.apns_team_id
+    SCHEDULER_SERVICE_ACCOUNT = module.call_dispatcher_service_account.email
+    DISPATCH_AUDIENCE         = local.dispatch_audience
   }
 
   secret_environment_variables = {
     AGENT_API_KEY = {
       secret_id = module.agent_api_key.secret_id
+      version   = "latest"
+    }
+    APNS_AUTH_KEY = {
+      secret_id = module.agent_apns_key.secret_id
       version   = "latest"
     }
   }
@@ -107,6 +159,31 @@ module "agent_cloud_run" {
   depends_on = [
     module.project_services,
     module.agent_api_key,
+    module.agent_apns_key,
     google_project_iam_member.agent_runtime_vertex,
+    google_project_iam_member.agent_runtime_datastore,
   ]
+}
+
+# =============================================================================
+# Cloud Scheduler
+# =============================================================================
+
+# 毎分 /internal/dispatch を叩き、期限が到来した電話予約に VoIP push を送らせる。
+module "call_dispatch_scheduler" {
+  source = "../../modules/cloud-scheduler-job"
+
+  project_id  = var.project_id
+  region      = var.region
+  name        = "${local.agent_name}-call-dispatch"
+  description = "期限到来した電話予約の VoIP push 送信（毎分・60秒先読みで秒精度発火）"
+  schedule    = "* * * * *"
+  # dispatch は次の60秒以内の予約を発火時刻まで待ってから送るため、1分より長めに取る
+  attempt_deadline = "90s"
+
+  uri                   = "${module.agent_cloud_run.service_uri}/internal/dispatch"
+  service_account_email = module.call_dispatcher_service_account.email
+  audience              = local.dispatch_audience
+
+  depends_on = [module.project_services]
 }

--- a/terraform/gcp/environments/prod/terraform.tfvars
+++ b/terraform/gcp/environments/prod/terraform.tfvars
@@ -1,0 +1,2 @@
+# APNs Auth Key の Key ID（charalarm と共用のチームキー。秘密情報ではない）
+apns_key_id = "NL6K5FR5S8"

--- a/terraform/gcp/environments/prod/variables.tf
+++ b/terraform/gcp/environments/prod/variables.tf
@@ -22,6 +22,24 @@ variable "gemini_model" {
   default     = "gemini-2.5-flash"
 }
 
+variable "agent_daily_limit" {
+  description = "deviceId ごとの /agent 日次呼び出し上限。0以下で無制限。"
+  type        = number
+  default     = 50
+}
+
+variable "apns_key_id" {
+  description = "APNs Auth Key (.p8) の Key ID。Apple Developer > Keys で作成したもの。"
+  type        = string
+  default     = ""
+}
+
+variable "apns_team_id" {
+  description = "Apple Developer の Team ID。"
+  type        = string
+  default     = "5RH346BQ66"
+}
+
 variable "image" {
   description = "Cloud Run の初期イメージ。実イメージは CI(agent-deploy.yml)が更新し、TF は ignore_changes で無視する。"
   type        = string


### PR DESCRIPTION
## 概要

prod GCP 環境が agent チャットのみの簡素な構成だったため、dev と同等の電話予約インフラを追加して自走できる環境にし、本番アプリを prod Cloud Run へ切り替えました。

## prod terraform に追加

- `roles/datastore.user`（レートリミット・電話予約の Firestore 読み書き）
- `AGENT_DAILY_LIMIT` 環境変数（デフォルト50）
- APNs secret（`.p8` は手動投入。dev と同一チームキー `NL6K5FR5S8`）
- `APNS_KEY_ID` / `APNS_TEAM_ID` / `SCHEDULER_SERVICE_ACCOUNT` / `DISPATCH_AUDIENCE`
- Cloud Scheduler（毎分 `/internal/dispatch`）+ ディスパッチャ SA
- `firestore` / `cloudscheduler` API の有効化

Firestore の `(default)` DB は dev が同一プロジェクトで共有管理しているため prod では再定義していません。

## iOS

- `Production.xcconfig` の `AGENT_BASE_URL` を dev から prod Cloud Run（`zuntalk-agent-prod`）へ切り替え

## 適用状況

- prod terraform は **適用済み**（Cloud Run リビジョン `00005-xsc`、Scheduler ENABLED、`/health` 200）
- prod Cloud Run は最新コード（`c1f203a`）で稼働

## 注意

- Firestore 共有のため dev/prod 2つの Scheduler が同じ `scheduledCalls` を見る。`ClaimCall` で二重送信は防げる（安全だが冗長）。将来 dev Scheduler 停止も選択肢。

🤖 Generated with [Claude Code](https://claude.com/claude-code)