### PR TITLE
エージェント API キーを dev/prod で分離

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -2,13 +2,14 @@
 
 ずんだもんの「エージェントモード」用バックエンド。ユーザーの発話に対し、
 
-1. **planner**（Gemini）が必要なツール（Gmail / Calendar）を計画
-2. **端末(iOS)** がその計画を実行（Calendar は EventKit、Gmail API は端末から直接叩く）
+1. **planner**（Gemini）が必要なツール（カレンダー）を計画
+2. **端末(iOS)** がその計画を実行（カレンダーは EventKit で端末内から読む）
 3. **responder**（Gemini）が結果を踏まえてずんだもん口調で応答
 
 を行う、AI オーケストレーション専任のサーバー（Go + Echo + Vertex AI）。
 
-> **セキュリティ方針**: ユーザーの Google アクセストークンはサーバーに一切保存しない。
+> **セキュリティ方針**: ユーザーの個人データ（カレンダー等）はサーバーに保存しない。
+> ツールは端末内で実行し、AI 応答生成に必要な結果テキストだけをサーバーに渡す。
 > サーバーが持つ秘密は自分の GCP/Vertex 権限のみ。
 
 ## 構成
@@ -32,33 +33,30 @@ orchestrator/          planner / responder（司令塔）
 ```jsonc
 // リクエスト
 {
-  "message": "予定とメールを確認して",
+  "message": "今日の予定を教えて",
   "capabilities": ["calendar"],
   "deviceId": "device-uuid"
 }
 // レスポンス
 { "type": "tool_calls",
   "plan": [
-    { "capability": "calendar", "query": "今日と明日の予定" },
-    { "capability": "gmail",    "query": "最近の重要なメール" }
+    { "capability": "calendar", "query": "今日と明日の予定" }
   ] }
 ```
 
 **2巡目（応答）** — 端末がツールを実行した結果を添えて再送
 ```jsonc
 // リクエスト
-{ "message": "予定とメールを確認して",
+{ "message": "今日の予定を教えて",
   "results": [
-    { "capability": "calendar", "content": "14:00 歯医者 / 18:00 MTG" },
-    { "capability": "gmail",    "content": "請求書の確認依頼が1件" }
+    { "capability": "calendar", "content": "14:00 歯医者 / 18:00 MTG" }
   ] }
 // レスポンス
 { "type": "final", "reply": "今日は14時に歯医者なのだ！…" }
 ```
 
-`capabilities` は端末が実行できるツールの申告。Production iOS は `calendar` のみ、
-Development iOS は Google 連携済みの場合に `gmail` も追加する。
-未指定の場合は後方互換として `calendar` / `gmail` の両方を利用可能とみなす。
+`capabilities` は端末が実行できるツールの申告。現状は `calendar`（EventKit）のみ。
+未指定の場合は後方互換として全ツール（= `calendar`）を利用可能とみなす。
 `deviceId` は日次利用回数制限に使う。
 
 雑談（ツール不要）の場合は1巡目で即 `type: "final"` が返る。
@@ -91,7 +89,7 @@ go run .
 # 4. 動作確認
 curl -XPOST localhost:8080/agent \
   -H 'Content-Type: application/json' \
-  -d '{"message":"予定とメールを確認して"}'
+  -d '{"message":"今日の予定を教えて"}'
 ```
 
 事前に対象プロジェクトで Vertex AI API を有効化しておくこと

--- a/agent/model/agent.go
+++ b/agent/model/agent.go
@@ -5,19 +5,16 @@ type Capability string
 
 const (
 	CapabilityCalendar Capability = "calendar"
-	CapabilityGmail    Capability = "gmail"
 )
 
 // AgentRequest は /agent エンドポイントへのリクエスト。
 //
 // ステートレス設計: 端末(iOS)が会話を駆動する。
 //   - 1巡目: Message のみ送る → サーバーは計画(Plan)を返す
-//   - 端末は Plan の各ステップを「自分の Keychain のトークン」で実行（Gmail/Calendar API は端末から叩く）
+//   - 端末は Plan の各ステップを実行（カレンダーは EventKit で端末内から読む）
 //   - 2巡目: Message ＋ Results（端末での実行結果）を送る → サーバーは最終応答(Reply)を返す
-//
-// ユーザーの Google トークンはサーバーに一切渡さない。
 type AgentRequest struct {
-	// Message はユーザーの発話（例: 「予定とメールを確認して」）。
+	// Message はユーザーの発話（例: 「今日の予定を教えて」）。
 	Message string `json:"message"`
 	// Results は端末がツールを実行した結果（2巡目以降のみ）。空なら計画フェーズ。
 	Results []StepResult `json:"results,omitempty"`

--- a/agent/orchestrator/orchestrator.go
+++ b/agent/orchestrator/orchestrator.go
@@ -1,8 +1,8 @@
 // Package orchestrator はずんだもんエージェントの司令塔。
 //
 // サーバー側は AI のオーケストレーション（planner と responder）のみを担う。
-// Gmail/Calendar の実際のAPI呼び出しは端末(iOS)が自分のトークンで行うため、
-// ここには実行ワーカー（gmail/calendar の API クライアント）は存在しない。
+// カレンダーの実際の読み取りは端末(iOS)が EventKit で行うため、
+// ここには実行ワーカー（ツールの API クライアント）は存在しない。
 package orchestrator
 
 import "github.com/takoikatakotako/ZunTalk/agent/llm"

--- a/agent/orchestrator/planner.go
+++ b/agent/orchestrator/planner.go
@@ -13,11 +13,10 @@ import (
 // capabilityDescriptions は planner のプロンプトに載せるツール説明。
 var capabilityDescriptions = map[model.Capability]string{
 	model.CapabilityCalendar: "カレンダーの予定を調べる（端末の標準カレンダー）",
-	model.CapabilityGmail:    "Gmailのメールを調べる",
 }
 
 // allCapabilities は既定のツール一覧（クライアントが capabilities を送らない場合の後方互換）。
-var allCapabilities = []model.Capability{model.CapabilityCalendar, model.CapabilityGmail}
+var allCapabilities = []model.Capability{model.CapabilityCalendar}
 
 // normalizeCapabilities はクライアント申告の capabilities を検証して返す。
 // 空・欠落なら全ツール（後方互換）、未知の値は除外する。

--- a/agent/orchestrator/planner_test.go
+++ b/agent/orchestrator/planner_test.go
@@ -16,12 +16,17 @@ func TestNormalizeCapabilities(t *testing.T) {
 		{
 			name:      "empty falls back to all capabilities",
 			requested: nil,
-			want:      []model.Capability{model.CapabilityCalendar, model.CapabilityGmail},
+			want:      []model.Capability{model.CapabilityCalendar},
 		},
 		{
 			name:      "unknown values are removed",
 			requested: []model.Capability{model.Capability("unknown"), model.CapabilityCalendar},
 			want:      []model.Capability{model.CapabilityCalendar},
+		},
+		{
+			name:      "removed gmail capability is treated as unknown",
+			requested: []model.Capability{model.Capability("gmail")},
+			want:      []model.Capability{},
 		},
 		{
 			name:      "only unknown values yield no capabilities",

--- a/docs/architecture/system.md
+++ b/docs/architecture/system.md
@@ -99,9 +99,9 @@
 - `POST /internal/dispatch`: Scheduler 専用（OIDC 検証）
 
 #### ツール（capability）と EventKit
-- 端末はリクエストで実行可能な capability を申告する（本番は `calendar` のみ、開発は Google 連携済みなら `gmail` も）
+- 端末はリクエストで実行可能な capability を申告する（現状は `calendar` のみ）
 - **カレンダーは EventKit で端末内の iOS 標準カレンダーを読む**（Google OAuth 審査が不要。Google アカウント同期済みの予定も読める）
-- Gmail は Google OAuth のテストモード運用（開発者専用、Debug ビルド限定）
+- Gmail 連携は廃止済み（アプリからも planner の capability からも削除）
 
 #### 利用回数制限
 - deviceId ごとに `/agent` を日次 `AGENT_DAILY_LIMIT` 回（デフォルト50、JST 0時リセット）まで。超過は 429
@@ -155,7 +155,7 @@
 ### エージェント会話フロー（2巡構造）
 
 1. **1巡目（計画）**: 端末 → `POST /agent {message, capabilities, deviceId}` → planner（Gemini）が実行計画を返す（ツール不要なら即最終応答）
-2. **端末ツール実行**: 計画の各ステップを端末で実行（calendar は EventKit、gmail は Gmail API を端末のトークンで直接）
+2. **端末ツール実行**: 計画の各ステップを端末で実行（calendar は EventKit で端末内カレンダーを読む）
 3. **2巡目（応答）**: 端末 → `POST /agent {message, results}` → responder（Gemini）がずんだもん口調の返答と感情を返す → VOICEVOX で再生
 
 ### 電話予約フロー

--- a/ios/Development.xcconfig
+++ b/ios/Development.xcconfig
@@ -1,7 +1,10 @@
 // Debug環境の設定
 
-// 機密設定（git管理外。AGENT_API_KEY を定義）。無くてもビルドは通る。
+// 機密設定（git管理外。AGENT_API_KEY_DEV / AGENT_API_KEY_PROD を定義）。無くてもビルドは通る。
 #include? "Secrets.xcconfig"
+
+// エージェント API キー。dev/prod でサーバー側と別々の値を使う。
+AGENT_API_KEY = $(AGENT_API_KEY_DEV)
 
 // API Base URL
 API_BASE_URL = https:/$()/d53er5cb4n63l2dbbkaqjqesde0lfgpb.lambda-url.ap-northeast-1.on.aws

--- a/ios/Production.xcconfig
+++ b/ios/Production.xcconfig
@@ -1,7 +1,10 @@
 // Release環境の設定
 
-// 機密設定（git管理外。AGENT_API_KEY を定義）。無くてもビルドは通る。
+// 機密設定（git管理外。AGENT_API_KEY_DEV / AGENT_API_KEY_PROD を定義）。無くてもビルドは通る。
 #include? "Secrets.xcconfig"
+
+// エージェント API キー。dev/prod でサーバー側と別々の値を使う。
+AGENT_API_KEY = $(AGENT_API_KEY_PROD)
 
 // API Base URL (TODO: 本番環境のURLに変更)
 API_BASE_URL = https:/$()/lywvkbddncitxwu436n6ypykd40hfytm.lambda-url.ap-northeast-1.on.aws

--- a/ios/Secrets.xcconfig.example
+++ b/ios/Secrets.xcconfig.example
@@ -1,2 +1,5 @@
-// このファイルを Secrets.xcconfig にコピーして AGENT_API_KEY を設定する（Cloud Run の agent-api-key）
-AGENT_API_KEY = your-agent-api-key-here
+// このファイルを Secrets.xcconfig にコピーして、dev/prod それぞれの
+// エージェント API キーを設定する（Cloud Run の secret zuntalk-agent-{dev,prod}-api-key）。
+// Development スキームは AGENT_API_KEY_DEV、Production スキームは AGENT_API_KEY_PROD を使う。
+AGENT_API_KEY_DEV = your-dev-agent-api-key-here
+AGENT_API_KEY_PROD = your-prod-agent-api-key-here

--- a/terraform/gcp/README.md
+++ b/terraform/gcp/README.md
@@ -2,7 +2,10 @@
 
 `agent/`（Go + Vertex AI）を Cloud Run にデプロイするための Terraform。
 既存 sandbox プロジェクト（`sandbox-492513`）に相乗りし、dev/prod で
-Artifact Registry / Cloud Run / Secret Manager / 実行SA を分離する。
+Artifact Registry / Cloud Run / Secret Manager / 実行SA / Firestore データベース /
+Cloud Scheduler を分離する。Firestore は dev が `(default)`、prod が名前付きDB
+`zuntalk-prod` を使い、データを完全分離する（将来 prod を別プロジェクト・
+別アカウントへ移してもコード変更なしで追従できる）。
 
 プロジェクト本体は `gcp-iac` リポジトリが管理している。ここでは `google_project` を作らず、
 中のリソースだけを追加する。
@@ -16,17 +19,24 @@ Artifact Registry / Cloud Run / Secret Manager / 実行SA を分離する。
 | `modules/artifact-registry` | Artifact Registry repository |
 | `modules/secret-manager-secret` | Secret Manager secret と accessor |
 | `modules/cloud-run` | Cloud Run service と invoker IAM |
+| `modules/cloud-scheduler-job` | Cloud Scheduler ジョブ（電話予約ディスパッチ） |
 | `environments/dev` | dev 環境。state prefix は `zuntalk-agent/dev` |
 | `environments/prod` | prod 環境。state prefix は `zuntalk-agent/prod` |
 
 環境ごとの主なリソース名:
 
-| 環境 | Cloud Run / Artifact Registry | Secret Manager |
-|---|---|---|
-| dev | `zuntalk-agent-dev` | `zuntalk-agent-dev-api-key` |
-| prod | `zuntalk-agent-prod` | `zuntalk-agent-prod-api-key` |
+| 環境 | Cloud Run / Artifact Registry | Secret Manager | Firestore DB |
+|---|---|---|---|
+| dev | `zuntalk-agent-dev` | `zuntalk-agent-dev-api-key` / `zuntalk-agent-dev-apns-key` | `(default)` |
+| prod | `zuntalk-agent-prod` | `zuntalk-agent-prod-api-key` / `zuntalk-agent-prod-apns-key` | `zuntalk-prod` |
+
+接続先の Firestore DB は Cloud Run の環境変数 `FIRESTORE_DATABASE` で切り替える
+（未設定なら `(default)`）。
 
 アクセス制御は Cloud Run を public にしつつ、Go 側の `X-Api-Key` 検証で保護する。
+**API キーは dev/prod で別の値**にする（独立してローテーションできるように）。
+iOS 側は `Secrets.xcconfig` に `AGENT_API_KEY_DEV` / `AGENT_API_KEY_PROD` を持ち、
+Development/Production スキームがそれぞれ対応する値を送る。
 
 ## bootstrap
 
@@ -40,19 +50,30 @@ cd terraform/gcp/environments/dev
 terraform init
 terraform apply
 
-# 3. dev API キーの値を投入
+# 3. dev API キーの値を投入（dev/prod で別の値にすること）
 printf '%s' "$(openssl rand -hex 32)" | \
   gcloud secrets versions add zuntalk-agent-dev-api-key --data-file=- --project=sandbox-492513
 
-# 4. prod の初回 apply
+# 4. APNs Auth Key (.p8) を dev secret に投入（電話予約の VoIP push 用）
+#    未投入のまま Cloud Run をデプロイすると起動に失敗する
+gcloud secrets versions add zuntalk-agent-dev-apns-key \
+  --data-file=AuthKey_XXXX.p8 --project=sandbox-492513
+
+# 5. prod の初回 apply
 cd ../prod
 terraform init
-terraform apply
+terraform apply   # 名前付きDB zuntalk-prod の作成にインデックス構築で数分かかる
 
-# 5. prod API キーの値を投入
+# 6. prod API キー（dev とは別値）と APNs Auth Key を投入
 printf '%s' "$(openssl rand -hex 32)" | \
   gcloud secrets versions add zuntalk-agent-prod-api-key --data-file=- --project=sandbox-492513
+gcloud secrets versions add zuntalk-agent-prod-apns-key \
+  --data-file=AuthKey_XXXX.p8 --project=sandbox-492513   # .p8 は dev と同一チームキーでよい
 ```
+
+`.p8` は環境非依存で、同じキーで sandbox / production の APNs 両方に送れる。
+投入した API キーは iOS の `Secrets.xcconfig`（`AGENT_API_KEY_DEV` / `AGENT_API_KEY_PROD`）
+にも設定する。
 
 その後 `agent/**` を main に push すると dev にデプロイする。prod は
 `.github/workflows/agent-deploy.yml` を手動実行して `environment=prod` を選択する。
@@ -66,5 +87,5 @@ curl "$RUN_URL/health"
 # /agent は X-Api-Key 必須
 curl -H "X-Api-Key: <投入した鍵>" -XPOST "$RUN_URL/agent" \
   -H 'Content-Type: application/json' \
-  -d '{"message":"予定とメールを確認して"}'
+  -d '{"message":"今日の予定を教えて","capabilities":["calendar"],"deviceId":"test"}'
 ```


### PR DESCRIPTION
## 概要

dev/prod のサーバー側 `AGENT_API_KEY` が完全に同一値だったため、独立してローテーションできるよう別キーに分離しました。prod には新しいキーを発行済みです。

## 変更

- `Secrets.xcconfig`（git 管理外）を `AGENT_API_KEY_DEV` / `AGENT_API_KEY_PROD` の2キー構成に
- `Development.xcconfig` → `AGENT_API_KEY = $(AGENT_API_KEY_DEV)`
- `Production.xcconfig` → `AGENT_API_KEY = $(AGENT_API_KEY_PROD)`
- `Secrets.xcconfig.example` を新構成に更新

## サーバー側（適用済み）

- prod の Secret Manager `zuntalk-agent-prod-api-key` に新バージョン投入 → prod 再デプロイで反映
- dev キーは据え置き（dev 環境に影響なし）

## 検証（prod /agent、E2E）

| リクエスト | 結果 |
|---|---|
| 新 prod キー | 200 ✅ |
| 旧 dev キー | 401 ✅ |
| キーなし | 401 ✅ |

prod は新キーのみを受け付け、dev キーでは弾かれることを確認。

## 補足

- この `AGENT_API_KEY` はクライアント埋め込みの共有シークレット（本質的に弱い）で、主眼はローテーションの独立性。実際のコスト保護は deviceId ごとのレートリミット。

🤖 Generated with [Claude Code](https://claude.com/claude-code)