### PR TITLE
fix(landing): OGP 画像を絶対URL化し SNS 共有の表示を修正

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -8,11 +8,19 @@
 
   <!-- Open Graph / SNS -->
   <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="ZunTalk" />
+  <meta property="og:locale" content="ja_JP" />
   <meta property="og:title" content="ZunTalk - ずんだもんと音声で会話できるiOSアプリ" />
   <meta property="og:description" content="ずんだもんと電話みたいに、音声で自然におしゃべり。AI × 音声認識 × 音声合成。" />
-  <meta property="og:image" content="assets/zundamon.png" />
+  <meta property="og:image" content="https://takoikatakotako.github.io/ZunTalk/assets/zundamon.png" />
+  <meta property="og:image:width" content="710" />
+  <meta property="og:image:height" content="709" />
+  <meta property="og:image:alt" content="ずんだもん" />
   <meta property="og:url" content="https://takoikatakotako.github.io/ZunTalk/" />
-  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="ZunTalk - ずんだもんと音声で会話できるiOSアプリ" />
+  <meta name="twitter:description" content="ずんだもんと電話みたいに、音声で自然におしゃべり。AI × 音声認識 × 音声合成。" />
+  <meta name="twitter:image" content="https://takoikatakotako.github.io/ZunTalk/assets/zundamon.png" />
 
   <link rel="icon" href="assets/icon.png" />
   <link rel="stylesheet" href="styles.css" />


### PR DESCRIPTION
## 概要

ランディングページ（https://takoikatakotako.github.io/ZunTalk/ ）を SNS でシェアすると表示が崩れる問題を修正します。

## 原因

- `og:image` が**相対パス**（`assets/zundamon.png`）だったため、Twitter/Slack/LINE 等のクローラーが画像を取得できず、共有時に画像が出ない。
- 画像が正方形（710×709）なのに `twitter:card` が `summary_large_image`（横長 1200×630 想定）で、大カード表示だと見切れる。

## 変更

- `og:image` を**絶対URL**に修正（主因）
- `twitter:card` を `summary`（正方形カード）に変更して見切れを防止
- `twitter:image` / `twitter:title` / `twitter:description`、`og:site_name` / `og:locale` / `og:image:width|height|alt` を追加

## 反映後の確認

デプロイ後、各社デバッガでキャッシュ更新すると確実です。
- X: https://cards-dev.twitter.com/validator
- Facebook/OG: https://developers.facebook.com/tools/debug/ （Scrape Again）

## 補足

今回は既存の立ち絵を正方形カードで綺麗に出す方針。横長の大カードにしたい場合は 1200×630 の OGP バナーを別途用意する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)